### PR TITLE
merge(dev→main): mobile mode-selector always shown at boot

### DIFF
--- a/packages/mobile/src/entry.tsx
+++ b/packages/mobile/src/entry.tsx
@@ -212,36 +212,6 @@ function App() {
   }
 
   onMount(() => {
-    // Auto-trigger the local connect at boot. The legacy selector (Local /
-    // Remote) was a development-time convenience; in normal use the user
-    // always picks Local, and on Android MIUI we cannot inject the click
-    // via `adb shell input` (security policy blocks INJECT_EVENTS unless a
-    // hidden devsetting toggle is on). Auto-connecting at mount removes
-    // that interaction entirely. To force the selector, set
-    // `localStorage.setItem("openCodeShowSelector","1")` from the WebView
-    // dev console before reload.
-    void (async () => {
-      try {
-        if (localStorage.getItem("openCodeShowSelector") === "1") return
-      } catch {}
-      // Fresh install / not-yet-extracted runtime: route through
-      // ExtractionProgress so install_extended_env runs (Alpine rootfs +
-      // toolchain wrappers). Without this, start_embedded_server fires
-      // before rootfs extraction and the cargo/rustc/python wrappers come
-      // up empty (rootfs missing).
-      try {
-        const { checkRuntime } = await import("./runtime")
-        const info = await checkRuntime()
-        if (!info.ready || !info.extended_env) {
-          setMode("extracting")
-          return
-        }
-      } catch {}
-      void handleLocalConnect()
-    })()
-  })
-
-  onMount(() => {
     // A.4-part1: pause/resume detection via visibilitychange.
     // On background: notify Rust (placeholder for foreground-service keepalive).
     // On resume: health-check and emit reload event if server died.


### PR DESCRIPTION
## Summary
- The mobile app's onMount auto-connect (added in 8e92945685) unconditionally called `handleLocalConnect()` on every cold start, skipping the Local/Remote mode-selector screen entirely unless a hidden dev-only localStorage flag was set.
- A previously-configured remote (TLS) server was therefore never offered again after any launch — `setDefaultServer()` persisted it correctly, but `getDefaultServer()` was never read at boot.
- Removed the auto-skip block. `ExtractionProgress` already runs its own `checkRuntime()`/`installExtendedEnv()` when the user picks Local from the selector, so this is a pure removal with no loss of behavior for fresh installs.

## Verification
- `bun run typecheck` — 15/15 packages pass.
- Built + signed + installed the APK on a real device (Xiaomi 14 Ultra); confirmed via screenshot that the mode selector ("Local Mode" / "Remote Server") renders on cold start.
- CI on `dev` (commit f0b3eb7f9a): typecheck, test, generate, nix-eval, deploy, CodeQL, Build Android APK all green.

## Test plan
- [x] typecheck
- [x] CI green on dev
- [x] Manual device verification (screenshot)