### PR TITLE
fix(github-bot): fetch the validated URL object, not the raw string

### DIFF
--- a/packages/opencode/src/cli/cmd/github-run.ts
+++ b/packages/opencode/src/cli/cmd/github-run.ts
@@ -569,47 +569,48 @@ export const GithubRunCommand = cmd({
             console.error("Rejected attachment URL: unparseable")
             continue
           }
-          if (parsedUrl.protocol !== "https:" || parsedUrl.hostname !== "github.com") {
+
+          // WHY the sink lives inside this positive equality check (rather
+          // than an early `if (bad) continue`): this is the barrier-guard
+          // shape CodeQL's SSRF taint tracker recognizes as sanitizing —
+          // the request is only ever reachable when hostname/protocol are
+          // proven equal to the fixed, trusted values.
+          if (parsedUrl.protocol === "https:" && parsedUrl.hostname === "github.com") {
+            const filename = path.basename(url)
+
+            const res = await fetch(parsedUrl, {
+              headers: {
+                Authorization: `Bearer ${appToken}`,
+                Accept: "application/vnd.github.v3+json",
+              },
+            })
+            if (!res.ok) {
+              // WHY replace() here: url comes from a GitHub comment body
+              // (untrusted input) and the regex above still allows raw
+              // control characters in its path segment — strip them before
+              // logging so a crafted comment can't forge fake log lines
+              // (CWE-117) in CI output.
+              console.error(`Failed to download image: ${url.replace(/[\x00-\x1f\x7f]/g, "")}`)
+              continue
+            }
+
+            // Replace img tag with file path, ie. @image.png
+            const replacement = `@${filename}`
+            prompt = prompt.slice(0, start + offset) + replacement + prompt.slice(start + offset + tag.length)
+            offset += replacement.length - tag.length
+
+            const contentType = res.headers.get("content-type")
+            imgData.push({
+              filename,
+              mime: contentType?.startsWith("image/") ? contentType : "text/plain",
+              content: Buffer.from(await res.arrayBuffer()).toString("base64"),
+              start,
+              end: start + replacement.length,
+              replacement,
+            })
+          } else {
             console.error("Rejected attachment URL: unexpected host")
-            continue
           }
-
-          const filename = path.basename(url)
-
-          // Download image. WHY fetch(parsedUrl) rather than fetch(url):
-          // requesting the validated URL object — not the original string —
-          // is what lets static analysis (and any future reviewer) confirm
-          // the network call can only ever target the host checked above.
-          const res = await fetch(parsedUrl, {
-            headers: {
-              Authorization: `Bearer ${appToken}`,
-              Accept: "application/vnd.github.v3+json",
-            },
-          })
-          if (!res.ok) {
-            // WHY replace() here: url comes from a GitHub comment body
-            // (untrusted input) and the regex above still allows raw
-            // control characters in its path segment — strip them before
-            // logging so a crafted comment can't forge fake log lines
-            // (CWE-117) in CI output.
-            console.error(`Failed to download image: ${url.replace(/[\x00-\x1f\x7f]/g, "")}`)
-            continue
-          }
-
-          // Replace img tag with file path, ie. @image.png
-          const replacement = `@${filename}`
-          prompt = prompt.slice(0, start + offset) + replacement + prompt.slice(start + offset + tag.length)
-          offset += replacement.length - tag.length
-
-          const contentType = res.headers.get("content-type")
-          imgData.push({
-            filename,
-            mime: contentType?.startsWith("image/") ? contentType : "text/plain",
-            content: Buffer.from(await res.arrayBuffer()).toString("base64"),
-            start,
-            end: start + replacement.length,
-            replacement,
-          })
         }
 
         return { userPrompt: prompt, promptFiles: imgData }

--- a/packages/opencode/src/cli/cmd/github-run.ts
+++ b/packages/opencode/src/cli/cmd/github-run.ts
@@ -576,8 +576,11 @@ export const GithubRunCommand = cmd({
 
           const filename = path.basename(url)
 
-          // Download image
-          const res = await fetch(url, {
+          // Download image. WHY fetch(parsedUrl) rather than fetch(url):
+          // requesting the validated URL object — not the original string —
+          // is what lets static analysis (and any future reviewer) confirm
+          // the network call can only ever target the host checked above.
+          const res = await fetch(parsedUrl, {
             headers: {
               Authorization: `Bearer ${appToken}`,
               Accept: "application/vnd.github.v3+json",


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] Bug fix

### What does this PR do?

Follow-up to #7 / #8. Those PRs added a hostname/protocol check before downloading
GitHub-hosted attachment images in `packages/opencode/src/cli/cmd/github-run.ts`, but
CodeQL alert #291 (critical, SSRF / `js/request-forgery`) stayed open: its taint tracker
does not credit a separate `if (bad) continue` guard as a barrier for the value that later
reaches `fetch()`, even when the guarded value itself (the parsed `URL` object) is what's
passed to `fetch()`.

This PR restructures the check into the barrier-guard shape CodeQL's SSRF query is known to
recognize: the `fetch()` call (and the rest of that loop iteration) now lives strictly inside
the `true` branch of `parsedUrl.protocol === "https:" && parsedUrl.hostname === "github.com"`,
instead of an early `continue` on the negated condition. No behavior change for well-formed
GitHub attachment URLs; malformed/non-`github.com` URLs are still rejected with the same log
message as before.

### How did you verify your code works?

- `bun run typecheck` passes (15/15 tasks).
- Verified via GitHub's code-scanning API that alert #291's most recent instance was still
  flagging the pre-restructure code at the exact `fetch()` line; this restructuring targets
  that specific taint-tracking gap.
- Waiting on this PR's own CodeQL run to confirm the alert clears against the new shape.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
