### PR TITLE
ci(fork-release): gate Tauri signing secrets behind release-signing environment

### DIFF
--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -109,6 +109,7 @@ jobs:
   build-tauri:
     needs: build-cli
     if: github.repository == 'Rwanbt/opencode'
+    environment: release-signing
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- Adds `environment: release-signing` to the `build-tauri` job in `fork-release.yml`.
- The two Tauri signing secrets (`TAURI_SIGNING_PRIVATE_KEY`, `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`) were plain repo-level secrets on a **public** repo with zero Environment protection (found during G-001 GitHub audit).
- `release-signing` Environment already created and configured (G-004, Unifia multi-AI runbook): required reviewer (Rwanbt), branch/tag policy restricted to `dev`, `main`, and `v*-fork*` tags.

## Context
Part of the Unifia multi-AI orchestration runbook, Programme G (GitHub hardening). Full audit trail in the Obsidian vault: `unifia-multi-ai-runbook/Logs/GITHUB-BASELINE-2026-07-20.md`, `unifia-multi-ai-runbook/Cards/G-004-*`.

Note: `publish.yml` also references these secret names but is gated with `if: github.repository == 'anomalyco/opencode'` — it never runs on this fork, so it is out of scope for this change.

## Remaining steps (not in this PR)
- [ ] Migrate the actual secret values into the `release-signing` Environment (`gh secret set TAURI_SIGNING_PRIVATE_KEY --env release-signing`, same for the password) — requires the secret owner, cannot be done by an agent.
- [ ] Once confirmed working, remove the old repo-level secrets.

## Test plan
- [x] `bun turbo typecheck` passes (ran automatically via pre-push hook).
- [ ] Manual: trigger `fork-release.yml` via `workflow_dispatch` after secrets are migrated, confirm the approval gate appears and the build succeeds once approved.