### PR TITLE
merge(dev→main): fix Settings dialog scroll regression on mobile

### DIFF
--- a/packages/mobile/src/mobile.css
+++ b/packages/mobile/src/mobile.css
@@ -644,7 +644,15 @@ a:active,
 @media (max-width: 767px), (max-height: 767px) {
   [data-component="dialog"][data-size="x-large"] [data-slot="dialog-container"] {
     width: 100vw !important;
-    height: auto !important;
+    /* Must stay a definite height (not auto): [data-component="dialog"] uses
+       align-items:center (not stretch), so an auto height here never gets a
+       flex-stretch fallback. dialog-content's max-height:100% (dialog.css)
+       only resolves against a definite parent height — with auto it silently
+       becomes unbounded, dialog-content grows to fit all Settings content,
+       and nothing is left to scroll (content just overflows past the screen
+       edge with no scrollbar). Regressed by 47ff606ebf, unrelated to that
+       commit's actual terminal-panel fix. */
+    height: var(--vvh, 100dvh) !important;
     max-height: var(--vvh, 100dvh) !important;
   }
 


### PR DESCRIPTION
## Summary
- Fixes a mobile regression where Settings screens (list + detail panels) could not be scrolled, making content below the fold unreachable.
- Root cause: commit 47ff606ebf changed the Settings dialog's `dialog-container` height from `var(--vvh, 100dvh)` to `auto` as a side effect of an unrelated terminal-panel fix in the same commit. Unlike the terminal panel (absolutely positioned with all 4 insets), the dialog relies on a definite parent height for `dialog-content`'s `max-height:100%` to resolve — with `auto` and `align-items:center` (not `stretch`) on the dialog's flex parent, that constraint silently became a no-op, so Settings content grew past the viewport with nothing left to scroll.
- Fix: restore the definite height for the Settings (`x-large`) dialog only; the terminal-panel `auto` height change from the same commit is left untouched since it's correct for that component's positioning model.

## Test plan
- [x] `bun test` on `packages/app/src/components/mobile-css-validation.test.ts` — 17/17 pass
- [x] Rebuilt Android APK (aarch64), signed with debug keystore, installed on physical device (Mi 10 Pro) — user manually verified scroll works in Settings after the fix