### PR TITLE
fix(ui): guard registerOpenCodeTheme against duplicate registration

### DIFF
--- a/packages/ui/src/pierre/opencode-theme.ts
+++ b/packages/ui/src/pierre/opencode-theme.ts
@@ -1,5 +1,7 @@
 import { registerCustomTheme, type ThemeRegistrationResolved } from "@pierre/diffs"
 
+let openCodeThemeRegistered = false
+
 // WHY this lives here (not just in context/marked.tsx, where it originated):
 // the Shiki worker pool used for the read-only file viewer (worker.ts in this
 // same directory) resolves themes by NAME on the main thread before handing
@@ -14,6 +16,9 @@ import { registerCustomTheme, type ThemeRegistrationResolved } from "@pierre/dif
 // Calling this from worker.ts too guarantees registration happens before the
 // pool ever needs it, regardless of whether markdown has rendered.
 export function registerOpenCodeTheme() {
+  if (openCodeThemeRegistered) return
+  openCodeThemeRegistered = true
+
   registerCustomTheme("OpenCode", () => {
     return Promise.resolve({
       name: "OpenCode",


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`registerOpenCodeTheme()` is called from both `context/marked.tsx` and the Shiki worker pool (`worker.ts`) to guarantee the theme is registered before either needs it. Without a guard, both call sites re-running `registerCustomTheme` repeatedly is harmless but wasteful — this adds a module-level flag so it only registers once.

### How did you verify your code works?

Small, self-contained change; verified `bun run typecheck` stays clean on `packages/ui`.

### Screenshots / recordings

Not applicable — internal idempotency guard, no visible behavior change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR