### PR TITLE
fix(brand): stop claiming a domain the project does not own

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,17 @@
 name: deploy
 
+# WHY manual-only: this deploys upstream's SaaS (Cloudflare hostnames under
+# opencode.ai, a Stripe webhook, PlanetScale branches) and this fork owns none
+# of it. The former `push: [dev, production]` trigger meant merging the rebrand
+# into `dev` would fire a deploy at infrastructure that is not ours. The fork
+# publishes no site — see infra/stage.ts and PROD_READINESS.md G9.
 on:
-  push:
-    branches:
-      - dev
-      - production
   workflow_dispatch:
+    inputs:
+      confirm_upstream_deploy:
+        description: "Type 'yes' to confirm this deploys infrastructure the fork does not own"
+        required: true
+        default: "no"
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -48,8 +54,12 @@ jobs:
           test -x "$STRIPE_PLUGIN_DIR/pulumi-resource-stripe"
 
       - name: Deploy
+        if: inputs.confirm_upstream_deploy == 'yes'
         run: bun sst deploy --stage=${{ github.ref_name }}
         env:
+          # Unlocks infra/stage.ts, which otherwise refuses to build a domain
+          # this fork does not own.
+          UNIFIA_ALLOW_UPSTREAM_DEPLOY: "1"
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           PLANETSCALE_SERVICE_TOKEN_NAME: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_NAME }}
           PLANETSCALE_SERVICE_TOKEN: ${{ secrets.PLANETSCALE_SERVICE_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,8 +54,10 @@ jobs:
 
       - name: Configure git identity
         run: |
-          git config --global user.email "bot@unifia.ai"
-          git config --global user.name "unifia"
+          # WHY noreply: no Unifia domain is controlled, so an @unifia.ai
+          # author address would be unroutable. This is GitHub's own bot identity.
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
 
       - name: Cache Turbo
         uses: actions/cache@v4

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -35,7 +35,12 @@ Les mainteneurs de projet sont responsables de clarifier et faire respecter nos 
 
 ## Signalement
 
-Pour signaler un comportement inacceptable, contactez : **conduct@unifia.ai**
+Pour signaler un comportement inacceptable, utilisez un signalement privé sur
+GitHub : [nouveau signalement privé](https://github.com/Rwanbt/unifia/security/advisories/new),
+ou contactez directement le mainteneur [@Rwanbt](https://github.com/Rwanbt).
+
+Le projet ne contrôle aucun nom de domaine et n'expose donc aucune adresse de
+contact e-mail ; toute adresse en `@unifia.ai` serait invalide.
 
 Toutes les complaints seront revues et traitées rapidement et équitablement.
 

--- a/PROD_READINESS.md
+++ b/PROD_READINESS.md
@@ -33,11 +33,12 @@ close que si la preuve citée existe et est reproductible. Rien ici ne peut
 | G6 | Dependabot | automatique | **PASS (activation)** / triage ouvert | Alertes et security updates **activées le 2026-08-11** (vérifié : `dependabot_security_updates: enabled`). 26 alertes ouvertes : 6 high, 16 medium, 4 low. Aucune PR de dépendance fusionnée |
 | G7 | Signature APK release + preuve device | **humaine** | **BLOCKED_HUMAN_INPUT** — blocage précisé | Ce qui est **disponible** : device ADB `b7163823` (Mi 10 Pro, `cmi_eea`) connecté, `ai.unifia.mobile` et `ai.opencode.mobile` y coexistent déjà ; `apksigner` présent en `%LOCALAPPDATA%\Android\Sdk\build-tools\35.0.0\` (hors PATH). Ce qui **manque** : aucun keystore Unifia n'existe sur cette machine (seuls `opencode-release.keystore` dans le checkout `D:\App\OpenCode\opencode` et `~/.android/debug.keystore`), et aucune des variables `UNIFIA_ANDROID_KEYSTORE`, `_KEY_ALIAS`, `_KEYSTORE_PASSWORD`, `_KEY_PASSWORD`, `_CERT_SHA256` n'est définie. **Conséquence à anticiper** : l'app installée est signée `848419ed` et marquée `DEBUGGABLE` (`lastUpdateTime=2026-08-10 01:05:04`) — un APK release ne s'installera pas par-dessus, il faudra désinstaller d'abord et perdre les données de l'app. Aucun keystore n'a été généré et aucune empreinte fabriquée : créer la clé de signature est une décision d'identité durable qui appartient au propriétaire. **Ce qui est prouvé le 2026-08-11, sur décision d'Erwan (build non signé uniquement)** : `bun run build:android` passe de bout en bout, bundle mobile régénéré compris — APK `app-universal-release-unsigned.apk`, 1067 Mo, 2026-08-11 16:19:45, SHA-256 `8E4EFD5C4BCB86F0132147D2CB1F789B29AF73A9E0954D9645BF80EA4C6291E3`. `apksigner verify` répond `DOES NOT VERIFY — Missing META-INF/MANIFEST.MF`, ce qui **prouve qu'aucune clé n'a été utilisée**, en particulier pas la clé debug. La chaîne de build n'est donc pas le blocage ; seule la clé l'est |
 | G8 | Identité produit | automatique | **PARTIEL** | Gate `identity` verte (surfaces, app IDs, adaptateurs générés). Résidus produit corrigés dans le runtime livré ; reste classé §0ter, dont `packages/web` bloqué par G9 |
-| G9 | Domaine / site de documentation | **humaine** | **BLOQUÉE** | Le fork ne contrôle aucun domaine. `packages/web` référence massivement `opencode.ai`. Décision requise : acquérir un domaine, ou tout pointer vers `github.com/Rwanbt/unifia`. **`unifia.ai` ne doit jamais être écrit** — non contrôlé |
+| G9 | Domaine / site de documentation | **humaine** | **DÉCIDÉE le 2026-08-11 — appliquée aux surfaces livrées** | Décision du propriétaire : **aucun domaine acquis**, le projet ne publie pas de site et sa localisation canonique est `github.com/Rwanbt/unifia`. Voir §0quater pour le périmètre exact, ce qui a été purgé et ce qui reste délibérément hors périmètre |
 | G10 | Publication externe | **humaine** | **NON DEMANDÉE** | Aucun paquet npm publié, aucune release GitHub créée, aucun APK/image Docker publié, `UNIFIA_ALLOW_UPSTREAM_PUBLISH` jamais défini |
 
 **Règle de promotion.** `feat/unifia-rebrand-complete → dev` (PR #23) ne peut
-pas être fusionnée tant que G4, G5, G7 et G9 sont ouvertes. G3 est une dette
+pas être fusionnée tant que G4, G5 et G7 sont ouvertes. G9 est close depuis le
+2026-08-11 (§0quater). G3 est une dette
 de la branche de base : elle doit être traitée pour elle-même, pas en bloquant
 les lots qui ne l'ont pas causée.
 
@@ -103,9 +104,41 @@ justifiée**. Classement des occurrences restantes :
 | **C — compatibilité** | `.opencode` en lecture, `LEGACY_CONFIG_FILES`, `LEGACY_DATABASE_FILE`, `opencode-<canal>.db`, `OPENCODE=1` (marqueur lu par des scripts utilisateurs, aucun consommateur interne) | **Conserver en lecture, écrire en Unifia** |
 | **E — amont** | `docs/autonomy/UPSTREAM-*`, `github-remote.test.ts`, `script/publish.ts` gardé par `UNIFIA_ALLOW_UPSTREAM_PUBLISH`, mentions explicites d'OpenCode dans README/SECURITY/AGENTS | **Conserver, marqué comme amont** |
 | **F — généré** | `assets/runtime/unifia-cli.js` et sa copie `gen/android/…` (contiennent encore `OPENCODE_CLIENT`) | **Aucune action** : `build:android` lance `bundle-mobile.mjs` avant tout build, donc la copie suivie est un cache régénéré, pas ce qui ship |
-| **G — web/domaine** | `packages/web/**` (~600 occurrences), i18n console | **Bloqué par G9** |
+| **G — web/domaine** | `packages/web/**`, `packages/console/**` | **Hors périmètre par décision G9** — surfaces de site non publiées par le fork ; voir §0quater |
 | **B — interne, différé** | ~50 tags de service Effect `@opencode/*` (clés de DI, jamais persistées ni visibles), thèmes `opencode.json`, `team/opencode-application.ts` | **Différé** : renommage mécanique à risque non nul et gain nul côté utilisateur ; ne pas le faire pour faire tomber un compteur |
 | **H — incertain** | `runtime/server.rs` exporte `UNIFIA_SERVER_USERNAME="opencode"` | **Ne pas toucher sans preuve device** : le nom d'utilisateur est saisi côté app ; le changer sans vérifier le chemin complet casserait l'auth mobile |
+
+### 0quater. Décision G9 — aucun domaine, localisation canonique GitHub
+
+**Décision du propriétaire, 2026-08-11** : le projet n'acquiert aucun domaine, ne
+publie aucun site, et sa localisation canonique est `github.com/Rwanbt/unifia`.
+
+Le point de départ était pire que « `packages/web` cite `opencode.ai` ». Le
+rebrand avait **fabriqué** `unifia.ai` dans des surfaces exécutables, alors que
+ce domaine n'est enregistré par personne — donc revendicable par un tiers.
+Corrigé ici :
+
+| Surface | Ce qui était écrit | Correctif |
+|---|---|---|
+| `infra/stage.ts` | `unifia.ai` comme domaine de production | Garde `UNIFIA_ALLOW_UPSTREAM_DEPLOY`, sur le modèle de `script/publish.ts` ; le domaine de production redevient celui d'amont, atteignable uniquement sous opt-in |
+| `.github/workflows/deploy.yml` | `push: [dev, production]` | `workflow_dispatch` avec confirmation explicite. **C'était le risque le plus concret : fusionner la PR #23 dans `dev` déclenchait un `sst deploy` vers une infrastructure qui n'est pas la nôtre** |
+| `CODE_OF_CONDUCT.md`, `SECURITY-INCIDENT-RESPONSE.md` | `conduct@` / `security@unifia.ai`, handle `@Unifia` | Signalement privé GitHub ; aucune adresse ni handle exposés |
+| `packages/desktop`, `packages/desktop-electron` | menu Documentation → `https://unifia.ai/docs` | → `github.com/Rwanbt/unifia#readme` |
+| `packages/app/src/i18n/*` (17 locales) | libellé `unifia.ai/zen` **alors que le `href` pointait sur `opencode.ai/zen`** | Libellé aligné sur la destination réelle |
+| `packages/app/src/entry.tsx` | branche `hostname.includes("unifia.ai")` | Supprimée : code mort, le fork ne sert depuis aucun domaine |
+| `packages/unifia/src/team/fencing.ts`, test helper | identités git `@unifia.ai` | `.invalid` (RFC 2606), non résoluble par construction |
+| TUI `tips-view`, ADR-0014, plan P15, README VS Code | domaine cité comme destination | Mention du domaine retirée |
+
+Un motif s'est répété : le rebrand a renommé le **texte** sans le **lien**
+(`[unifia.ai/zen](https://opencode.ai/zen)`, bouton copiant `opencode.ai/install`
+sous un libellé `unifia.ai/install`). Vérifier les deux sens à chaque renommage.
+
+**Délibérément hors périmètre** : `packages/web` et `packages/console` sont les
+surfaces de site. Le fork ne les publie pas et leur déploiement est neutralisé
+ci-dessus ; les réécrire n'apporterait rien tant qu'aucun site n'existe. Elles
+restent classées **G**. Les occurrences subsistant ailleurs sont **descriptives**
+(rapports d'audit, plans, interdictions explicites) et ne dirigent personne vers
+le domaine.
 
 ---
 

--- a/SECURITY-INCIDENT-RESPONSE.md
+++ b/SECURITY-INCIDENT-RESPONSE.md
@@ -50,7 +50,7 @@ Ce document décrit le **process de réponse** aux incidents de sécurité d'Uni
 
 - **Sources** : audit interne, rapport utilisateur, CVE database, scanner
 - **Action** : créer un ticket privé (NE PAS ouvrir d'issue publique)
-- **Destinataires** : security@unifia.ai (BDFL + 2 maintainers)
+- **Destinataires** : [signalement privé GitHub](https://github.com/Rwanbt/unifia/security/advisories/new) (le projet ne contrôle aucun domaine, donc aucune adresse e-mail)
 
 ### 2. Triage (15-60 min)
 
@@ -99,7 +99,7 @@ Ce document décrit le **process de réponse** aux incidents de sécurité d'Uni
 
 - Slack #security-incidents
 - PagerDuty (SEV-1, SEV-2)
-- Email security@unifia.ai
+- Signalement privé GitHub (aucune adresse e-mail : aucun domaine contrôlé)
 
 ### Externe
 
@@ -181,9 +181,12 @@ Nous suivons **90 days** comme standard depuis la découverte :
 
 ## Security contacts
 
-- **Email** : security@unifia.ai
-- **PGP key** : [à publier]
-- **Twitter** : @Unifia (SEV-1 only)
+- **Signalement privé** : https://github.com/Rwanbt/unifia/security/advisories/new
+- **Mainteneur** : [@Rwanbt](https://github.com/Rwanbt)
+
+Le projet ne contrôle ni nom de domaine ni compte de réseau social ; il n'expose
+donc ni adresse e-mail ni handle. Tout canal en `@unifia.ai` ou `@Unifia` serait
+usurpable par un tiers.
 
 ## Hall of Fame
 

--- a/docs/adr/0014-provider-unifia-native.md
+++ b/docs/adr/0014-provider-unifia-native.md
@@ -47,7 +47,7 @@ export const UnifiaProvider: Provider = {
 {
   "provider": "unifia",
   "unifia": {
-    "endpoint": "local",  // ou "https://api.unifia.ai"
+    "endpoint": "local",  // ou l'URL d'un runtime distant que vous hébergez
     "apiKey": null  // pas requis pour local
   }
 }

--- a/docs/autonomy/plans/P15-C1500-A-skill-hub.md
+++ b/docs/autonomy/plans/P15-C1500-A-skill-hub.md
@@ -25,7 +25,7 @@ interface SkillRegistry {
 ### Distribution
 
 - **Local** : `~/.config/unifia/skills/`
-- **Remote** : `unifia.ai/skills/{name}`
+- **Remote** : non planifié — le projet ne contrôle aucun domaine (voir G9)
 - **Git** : `github.com/{user}/{skill}`
 
 ### Package format

--- a/infra/stage.ts
+++ b/infra/stage.ts
@@ -1,5 +1,22 @@
+// Upstream's deployment path: it provisions Cloudflare hostnames, a Stripe
+// webhook and PlanetScale branches under domains upstream owns (opencode.ai,
+// opncd.ai) in upstream's Cloudflare zone. This fork owns no domain, so a
+// deploy from here can only fail or mutate infrastructure that is not ours.
+// Same gate, and same reason, as script/publish.ts.
+//
+// G9 decision (2026-08-11): the fork ships no website and claims no domain.
+// Its canonical location is https://github.com/Rwanbt/unifia. The production
+// domain below is upstream's real one — reachable only under this opt-in — so
+// that no Unifia domain is ever fabricated in source.
+if (!process.env["UNIFIA_ALLOW_UPSTREAM_DEPLOY"]) {
+  throw new Error(
+    "infra/ is upstream's deployment path and targets domains this fork does not own. " +
+      "Unifia publishes no site; its canonical location is https://github.com/Rwanbt/unifia.",
+  )
+}
+
 export const domain = (() => {
-  if ($app.stage === "production") return "unifia.ai"
+  if ($app.stage === "production") return "opencode.ai"
   if ($app.stage === "dev") return "dev.opencode.ai"
   return `${$app.stage}.dev.opencode.ai`
 })()

--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -98,7 +98,9 @@ if (!(root instanceof HTMLElement) && import.meta.env.DEV) {
 }
 
 const getCurrentUrl = () => {
-  if (location.hostname.includes("unifia.ai")) return "http://localhost:4096"
+  // WHY no marketing-host branch: upstream special-cased its own site host to
+  // fall back to a local server. This fork controls no domain and publishes no
+  // site (see PROD_READINESS.md G9), so that branch was unreachable here.
   if (import.meta.env.DEV)
     return `http://${import.meta.env.VITE_OPENCODE_SERVER_HOST ?? "localhost"}:${import.meta.env.VITE_OPENCODE_SERVER_PORT ?? "4096"}`
   return location.origin

--- a/packages/app/src/i18n/ar.ts
+++ b/packages/app/src/i18n/ar.ts
@@ -125,7 +125,7 @@ export const dict = {
   "provider.connect.opencodeZen.line2":
     "باستخدام مفتاح API واحد، ستحصل على إمكانية الوصول إلى نماذج مثل Claude و GPT و Gemini و GLM والمزيد.",
   "provider.connect.opencodeZen.visit.prefix": "قم بزيارة ",
-  "provider.connect.opencodeZen.visit.link": "unifia.ai/zen",
+  "provider.connect.opencodeZen.visit.link": "opencode.ai/zen",
   "provider.connect.opencodeZen.visit.suffix": " للحصول على مفتاح API الخاص بك.",
   "provider.connect.oauth.code.visit.prefix": "قم بزيارة ",
   "provider.connect.oauth.code.visit.link": "هذا الرابط",

--- a/packages/app/src/i18n/br.ts
+++ b/packages/app/src/i18n/br.ts
@@ -125,7 +125,7 @@ export const dict = {
   "provider.connect.opencodeZen.line2":
     "Com uma única chave de API você terá acesso a modelos como Claude, GPT, Gemini, GLM e mais.",
   "provider.connect.opencodeZen.visit.prefix": "Visite ",
-  "provider.connect.opencodeZen.visit.link": "unifia.ai/zen",
+  "provider.connect.opencodeZen.visit.link": "opencode.ai/zen",
   "provider.connect.opencodeZen.visit.suffix": " para obter sua chave de API.",
   "provider.connect.oauth.code.visit.prefix": "Visite ",
   "provider.connect.oauth.code.visit.link": "este link",

--- a/packages/app/src/i18n/bs.ts
+++ b/packages/app/src/i18n/bs.ts
@@ -137,7 +137,7 @@ export const dict = {
   "provider.connect.opencodeZen.line2":
     "Sa jednim API ključem dobijaš pristup modelima kao što su Claude, GPT, Gemini, GLM i drugi.",
   "provider.connect.opencodeZen.visit.prefix": "Posjeti ",
-  "provider.connect.opencodeZen.visit.link": "unifia.ai/zen",
+  "provider.connect.opencodeZen.visit.link": "opencode.ai/zen",
   "provider.connect.opencodeZen.visit.suffix": " da preuzmeš svoj API ključ.",
   "provider.connect.oauth.code.visit.prefix": "Posjeti ",
   "provider.connect.oauth.code.visit.link": "ovaj link",

--- a/packages/app/src/i18n/da.ts
+++ b/packages/app/src/i18n/da.ts
@@ -137,7 +137,7 @@ export const dict = {
   "provider.connect.opencodeZen.line2":
     "Med en enkelt API-nøgle får du adgang til modeller som Claude, GPT, Gemini, GLM og flere.",
   "provider.connect.opencodeZen.visit.prefix": "Besøg ",
-  "provider.connect.opencodeZen.visit.link": "unifia.ai/zen",
+  "provider.connect.opencodeZen.visit.link": "opencode.ai/zen",
   "provider.connect.opencodeZen.visit.suffix": " for at hente din API-nøgle.",
   "provider.connect.oauth.code.visit.prefix": "Besøg ",
   "provider.connect.oauth.code.visit.link": "dette link",

--- a/packages/app/src/i18n/de.ts
+++ b/packages/app/src/i18n/de.ts
@@ -129,7 +129,7 @@ export const dict = {
   "provider.connect.opencodeZen.line2":
     "Mit einem einzigen API-Schlüssel erhalten Sie Zugriff auf Modelle wie Claude, GPT, Gemini, GLM und mehr.",
   "provider.connect.opencodeZen.visit.prefix": "Besuchen Sie ",
-  "provider.connect.opencodeZen.visit.link": "unifia.ai/zen",
+  "provider.connect.opencodeZen.visit.link": "opencode.ai/zen",
   "provider.connect.opencodeZen.visit.suffix": ", um Ihren API-Schlüssel zu erhalten.",
   "provider.connect.oauth.code.visit.prefix": "Besuchen Sie ",
   "provider.connect.oauth.code.visit.link": "diesen Link",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -160,7 +160,7 @@ export const dict = {
   "provider.connect.opencodeZen.line2":
     "With a single API key you'll get access to models such as Claude, GPT, Gemini, GLM and more.",
   "provider.connect.opencodeZen.visit.prefix": "Visit ",
-  "provider.connect.opencodeZen.visit.link": "unifia.ai/zen",
+  "provider.connect.opencodeZen.visit.link": "opencode.ai/zen",
   "provider.connect.opencodeZen.visit.suffix": " to collect your API key.",
   "provider.connect.oauth.code.visit.prefix": "Visit ",
   "provider.connect.oauth.code.visit.link": "this link",

--- a/packages/app/src/i18n/es.ts
+++ b/packages/app/src/i18n/es.ts
@@ -125,7 +125,7 @@ export const dict = {
   "provider.connect.opencodeZen.line2":
     "Con una sola clave API obtendrás acceso a modelos como Claude, GPT, Gemini, GLM y más.",
   "provider.connect.opencodeZen.visit.prefix": "Visita ",
-  "provider.connect.opencodeZen.visit.link": "unifia.ai/zen",
+  "provider.connect.opencodeZen.visit.link": "opencode.ai/zen",
   "provider.connect.opencodeZen.visit.suffix": " para obtener tu clave API.",
   "provider.connect.oauth.code.visit.prefix": "Visita ",
   "provider.connect.oauth.code.visit.link": "este enlace",

--- a/packages/app/src/i18n/fr.ts
+++ b/packages/app/src/i18n/fr.ts
@@ -133,7 +133,7 @@ export const dict = {
   "provider.connect.opencodeZen.line2":
     "Avec une seule clé API, vous aurez accès à des modèles tels que Claude, GPT, Gemini, GLM et plus encore.",
   "provider.connect.opencodeZen.visit.prefix": "Visitez ",
-  "provider.connect.opencodeZen.visit.link": "unifia.ai/zen",
+  "provider.connect.opencodeZen.visit.link": "opencode.ai/zen",
   "provider.connect.opencodeZen.visit.suffix": " pour récupérer votre clé API.",
   "provider.connect.oauth.code.visit.prefix": "Visitez ",
   "provider.connect.oauth.code.visit.link": "ce lien",

--- a/packages/app/src/i18n/ja.ts
+++ b/packages/app/src/i18n/ja.ts
@@ -124,7 +124,7 @@ export const dict = {
     "Unifia Zenは、コーディングエージェント向けに最適化された信頼性の高いモデルへのアクセスを提供します。",
   "provider.connect.opencodeZen.line2": "1つのAPIキーで、Claude、GPT、Gemini、GLMなどのモデルにアクセスできます。",
   "provider.connect.opencodeZen.visit.prefix": " ",
-  "provider.connect.opencodeZen.visit.link": "unifia.ai/zen",
+  "provider.connect.opencodeZen.visit.link": "opencode.ai/zen",
   "provider.connect.opencodeZen.visit.suffix": " にアクセスしてAPIキーを取得してください。",
   "provider.connect.oauth.code.visit.prefix": " ",
   "provider.connect.oauth.code.visit.link": "このリンク",

--- a/packages/app/src/i18n/ko.ts
+++ b/packages/app/src/i18n/ko.ts
@@ -129,7 +129,7 @@ export const dict = {
     "Unifia Zen은 코딩 에이전트를 위해 최적화된 신뢰할 수 있는 엄선된 모델에 대한 액세스를 제공합니다.",
   "provider.connect.opencodeZen.line2": "단일 API 키로 Claude, GPT, Gemini, GLM 등 다양한 모델에 액세스할 수 있습니다.",
   "provider.connect.opencodeZen.visit.prefix": "다음 ",
-  "provider.connect.opencodeZen.visit.link": "unifia.ai/zen",
+  "provider.connect.opencodeZen.visit.link": "opencode.ai/zen",
   "provider.connect.opencodeZen.visit.suffix": "을 방문하여 API 키를 받으세요.",
   "provider.connect.oauth.code.visit.prefix": "다음 ",
   "provider.connect.oauth.code.visit.link": "이 링크",

--- a/packages/app/src/i18n/no.ts
+++ b/packages/app/src/i18n/no.ts
@@ -127,7 +127,7 @@ export const dict = {
   "provider.connect.opencodeZen.line2":
     "Med én enkelt API-nøkkel får du tilgang til modeller som Claude, GPT, Gemini, GLM og flere.",
   "provider.connect.opencodeZen.visit.prefix": "Besøk ",
-  "provider.connect.opencodeZen.visit.link": "unifia.ai/zen",
+  "provider.connect.opencodeZen.visit.link": "opencode.ai/zen",
   "provider.connect.opencodeZen.visit.suffix": " for å hente API-nøkkelen din.",
   "provider.connect.oauth.code.visit.prefix": "Besøk ",
   "provider.connect.oauth.code.visit.link": "denne lenken",

--- a/packages/app/src/i18n/pl.ts
+++ b/packages/app/src/i18n/pl.ts
@@ -125,7 +125,7 @@ export const dict = {
   "provider.connect.opencodeZen.line2":
     "Z jednym kluczem API uzyskasz dostęp do modeli takich jak Claude, GPT, Gemini, GLM i więcej.",
   "provider.connect.opencodeZen.visit.prefix": "Odwiedź ",
-  "provider.connect.opencodeZen.visit.link": "unifia.ai/zen",
+  "provider.connect.opencodeZen.visit.link": "opencode.ai/zen",
   "provider.connect.opencodeZen.visit.suffix": ", aby odebrać swój klucz API.",
   "provider.connect.oauth.code.visit.prefix": "Odwiedź ",
   "provider.connect.oauth.code.visit.link": "ten link",

--- a/packages/app/src/i18n/ru.ts
+++ b/packages/app/src/i18n/ru.ts
@@ -125,7 +125,7 @@ export const dict = {
   "provider.connect.opencodeZen.line2":
     "С одним API ключом вы получите доступ к таким моделям как Claude, GPT, Gemini, GLM и другим.",
   "provider.connect.opencodeZen.visit.prefix": "Посетите ",
-  "provider.connect.opencodeZen.visit.link": "unifia.ai/zen",
+  "provider.connect.opencodeZen.visit.link": "opencode.ai/zen",
   "provider.connect.opencodeZen.visit.suffix": " чтобы получить ваш API ключ.",
   "provider.connect.oauth.code.visit.prefix": "Посетите ",
   "provider.connect.oauth.code.visit.link": "эту ссылку",

--- a/packages/app/src/i18n/th.ts
+++ b/packages/app/src/i18n/th.ts
@@ -137,7 +137,7 @@ export const dict = {
   "provider.connect.opencodeZen.line2":
     "ด้วยคีย์ API เดียวคุณจะได้รับการเข้าถึงโมเดล เช่น Claude, GPT, Gemini, GLM และอื่น ๆ",
   "provider.connect.opencodeZen.visit.prefix": "เยี่ยมชม ",
-  "provider.connect.opencodeZen.visit.link": "unifia.ai/zen",
+  "provider.connect.opencodeZen.visit.link": "opencode.ai/zen",
   "provider.connect.opencodeZen.visit.suffix": " เพื่อรวบรวมคีย์ API ของคุณ",
   "provider.connect.oauth.code.visit.prefix": "เยี่ยมชม ",
   "provider.connect.oauth.code.visit.link": "ลิงก์นี้",

--- a/packages/app/src/i18n/tr.ts
+++ b/packages/app/src/i18n/tr.ts
@@ -127,7 +127,7 @@ export const dict = {
   "provider.connect.opencodeZen.line2":
     "Tek bir API anahtarıyla Claude, GPT, Gemini, GLM ve daha fazlası gibi modellere erişebilirsiniz.",
   "provider.connect.opencodeZen.visit.prefix": "",
-  "provider.connect.opencodeZen.visit.link": "unifia.ai/zen",
+  "provider.connect.opencodeZen.visit.link": "opencode.ai/zen",
   "provider.connect.opencodeZen.visit.suffix": " adresini ziyaret ederek API anahtarınızı alın.",
   "provider.connect.oauth.code.visit.prefix":
     "Hesabınızı bağlamak ve Unifia'da {{provider}} modellerini kullanmak için ",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -161,7 +161,7 @@ export const dict = {
   "provider.connect.opencodeZen.line1": "Unifia Zen 为你提供一组精选的可靠优化模型，用于代码智能体。",
   "provider.connect.opencodeZen.line2": "只需一个 API 密钥，你就能使用 Claude、GPT、Gemini、GLM 等模型。",
   "provider.connect.opencodeZen.visit.prefix": "访问 ",
-  "provider.connect.opencodeZen.visit.link": "unifia.ai/zen",
+  "provider.connect.opencodeZen.visit.link": "opencode.ai/zen",
   "provider.connect.opencodeZen.visit.suffix": " 获取你的 API 密钥。",
   "provider.connect.oauth.code.visit.prefix": "访问 ",
   "provider.connect.oauth.code.visit.link": "此链接",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -139,7 +139,7 @@ export const dict = {
   "provider.connect.opencodeZen.line1": "Unifia Zen 為你提供一組精選的可靠最佳化模型，用於程式碼代理程式。",
   "provider.connect.opencodeZen.line2": "只需一個 API 金鑰，你就能使用 Claude、GPT、Gemini、GLM 等模型。",
   "provider.connect.opencodeZen.visit.prefix": "造訪 ",
-  "provider.connect.opencodeZen.visit.link": "unifia.ai/zen",
+  "provider.connect.opencodeZen.visit.link": "opencode.ai/zen",
   "provider.connect.opencodeZen.visit.suffix": " 取得你的 API 金鑰。",
   "provider.connect.oauth.code.visit.prefix": "造訪 ",
   "provider.connect.oauth.code.visit.link": "此連結",

--- a/packages/desktop-electron/src/main/menu.ts
+++ b/packages/desktop-electron/src/main/menu.ts
@@ -120,7 +120,7 @@ export function createMenu(deps: Deps) {
     {
       label: "Help",
       submenu: [
-        { label: "Unifia Documentation", click: () => shell.openExternal("https://unifia.ai/docs") },
+        { label: "Unifia Documentation", click: () => shell.openExternal("https://github.com/Rwanbt/unifia#readme") },
         { label: "Support Forum", click: () => shell.openExternal("https://github.com/Rwanbt/unifia") },
         { type: "separator" },
         { type: "separator" },

--- a/packages/desktop/src/menu.ts
+++ b/packages/desktop/src/menu.ts
@@ -158,7 +158,7 @@ export async function createMenu(trigger: (id: string) => void) {
         items: [
           // missing native macos search
           await MenuItem.new({
-            action: () => openUrl("https://unifia.ai/docs"),
+            action: () => openUrl("https://github.com/Rwanbt/unifia#readme"),
             text: t("desktop.menu.help.documentation"),
           }),
           await MenuItem.new({

--- a/packages/unifia/src/cli/cmd/tui/feature-plugins/home/tips-view.tsx
+++ b/packages/unifia/src/cli/cmd/tui/feature-plugins/home/tips-view.tsx
@@ -54,7 +54,7 @@ const TIPS = [
   "Press {highlight}Tab{/highlight} to cycle between Build and Plan agents",
   "Use {highlight}/undo{/highlight} to revert the last message and file changes",
   "Use {highlight}/redo{/highlight} to restore previously undone messages and file changes",
-  "Run {highlight}/share{/highlight} to create a public link to your conversation at unifia.ai",
+  "Run {highlight}/share{/highlight} to create a public link to your conversation",
   "Drag and drop images into the terminal to add them as context",
   "Press {highlight}Ctrl+V{/highlight} to paste images from your clipboard into the prompt",
   "Press {highlight}Ctrl+X E{/highlight} or {highlight}/editor{/highlight} to compose messages in your external editor",

--- a/packages/unifia/src/server/server.ts
+++ b/packages/unifia/src/server/server.ts
@@ -74,7 +74,7 @@ export namespace Server {
             )
               return input
 
-            // Explicit unifia.ai origins we actually use — narrower than
+            // Explicit upstream opencode.ai origins we actually use — narrower than
             // the previous *.opencode.ai regex, which would accept anything
             // user-controlled at a hostile subdomain (e.g. evil.opencode.ai).
             const ALLOWED_OPENCODE_ORIGINS = [

--- a/packages/unifia/src/team/fencing.ts
+++ b/packages/unifia/src/team/fencing.ts
@@ -121,9 +121,9 @@ export function persistGitRef(
         env: {
           ...process.env,
           GIT_AUTHOR_NAME: "team-fencing",
-          GIT_AUTHOR_EMAIL: "team-fencing@unifia.ai",
+          GIT_AUTHOR_EMAIL: "team-fencing@unifia.invalid",
           GIT_COMMITTER_NAME: "team-fencing",
-          GIT_COMMITTER_EMAIL: "team-fencing@unifia.ai",
+          GIT_COMMITTER_EMAIL: "team-fencing@unifia.invalid",
           GIT_AUTHOR_DATE: "2026-07-21T00:00:00Z",
           GIT_COMMITTER_DATE: "2026-07-21T00:00:00Z",
         },

--- a/packages/unifia/test/team/helper.ts
+++ b/packages/unifia/test/team/helper.ts
@@ -28,7 +28,7 @@ export function createTempGitRepo(opts?: { branch?: string }): {
   // --initial-branch keeps newer git from complaining on Windows.
   const branch = opts?.branch ?? "main";
   execSync("git init -q -b " + branch, { cwd: dir });
-  execSync(`git config user.email "mm2@unifia.ai"`, { cwd: dir });
+  execSync(`git config user.email "mm2@unifia.invalid"`, { cwd: dir });
   execSync(`git config user.name "MM2-IMPLEMENTATION-LANE-A"`, { cwd: dir });
   execSync(`git config commit.gpgsign false`, { cwd: dir });
   // Make Windows tolerant.

--- a/sdks/vscode/README.md
+++ b/sdks/vscode/README.md
@@ -1,10 +1,12 @@
 # unifia VS Code Extension
 
-A Visual Studio Code extension that integrates [unifia](https://opencode.ai) directly into your development workflow.
+A Visual Studio Code extension that integrates [unifia](https://github.com/Rwanbt/unifia) directly into your development workflow.
 
 ## Prerequisites
 
-This extension requires the [unifia CLI](https://opencode.ai) to be installed on your system. Visit [unifia.ai](https://opencode.ai) for installation instructions.
+This extension requires the [unifia CLI](https://github.com/Rwanbt/unifia) to be installed on your system. See
+[the repository README](https://github.com/Rwanbt/unifia#readme) for installation instructions. This fork controls no
+domain and does not use upstream's installer — see `docs/FORK-DISTRIBUTION.md`.
 
 ## Features
 


### PR DESCRIPTION
### Issue for this PR

Closes #31

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The owner decided G9 on 2026-08-11: no domain is acquired, the project ships no
website, and its canonical location is `github.com/Rwanbt/unifia`.

The problem was not that `packages/web` quotes `opencode.ai`. It is that the
rebrand invented `unifia.ai` — a domain nobody has registered — and put it in
places that execute. Anyone can register it, so each of these is a handle on
our users rather than a cosmetic typo.

What changes, and why each works:

- `infra/stage.ts` now refuses to build a domain unless
  `UNIFIA_ALLOW_UPSTREAM_DEPLOY` is set, the same guard `script/publish.ts`
  already uses for the same reason. The production domain reverts to upstream's
  real one, so no Unifia domain is fabricated in source at all.
- `deploy.yml` was triggered by `push: [dev, production]`. Since PR #23 merges
  into `dev`, that merge would have run `sst deploy` against Cloudflare
  hostnames, a Stripe webhook and PlanetScale branches we do not own. It is now
  `workflow_dispatch` with an explicit confirmation input, and only that path
  sets the env var above. This was the concrete hazard, not a hypothetical one.
- The Code of Conduct and the incident-response doc pointed reporters at
  `conduct@` and `security@unifia.ai`. Those mailboxes cannot exist. They now
  use GitHub private reporting, so a report reaches someone.
- Both desktop menus opened `https://unifia.ai/docs`; they now open the repo.
- 17 locales displayed `unifia.ai/zen` on a link whose `href` was
  `opencode.ai/zen`. The label now states the real destination.
- `entry.tsx` branched on hostname `unifia.ai`. That branch could never be
  taken, since the fork serves from no domain, so it is deleted.
- Synthetic git identities move to `.invalid` (RFC 2606), which cannot resolve.

`packages/web` and `packages/console` are deliberately untouched. They are the
website surfaces, the fork does not publish them, and their deploy is disabled
above. Rewriting ~3100 strings there buys nothing while no site exists. The
mentions that remain elsewhere are descriptive — audit reports and explicit
prohibitions — and send nobody to the domain.

One pattern is worth carrying forward: the rebrand renamed link *text* without
renaming the *link*. The same shape is still visible in the console download
page, which copies `opencode.ai/install` under a label reading
`unifia.ai/install`. Check both directions when renaming.

### How did you verify your code works?

- `bun turbo typecheck --force`: 35/35 successful.
- `node scripts/identity/check.mjs`: 7 surfaces agree with `config/identity.json`.
- `node scripts/brand/check.mjs`: 30/30 masters and 208/208 generated verified.
- `packages/app`: 686 pass, 0 fail, 28223 expectations across 87 files.
- Parsed both edited workflows; `deploy.yml` now exposes only
  `workflow_dispatch`, which is the property that actually removes the risk.
- `bunx biome check` clean on the edited sources. Four of the touched files
  fail `prettier --check`, but they already did so before this branch — I
  verified that against the pristine tree rather than assuming it.

### Screenshots / recordings

Not a visual change: the user-visible effect is that two menu entries and one
provider link now resolve instead of dead-ending.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR