### PR TITLE
fix(release): repair stale workflow references

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   # schedule trigger disabled: this syncs "beta"-labeled team PRs, which this
   # solo fork doesn't receive, and its blacksmith-4vcpu-ubuntu-2404 runner was
-  # never migrated (see fork-release.yml / build-tauri using ubuntu-latest),
+  # never migrated (see release.yml / build-tauri using ubuntu-latest),
   # so hourly runs queued forever without executing.
   # - cron: "0 * * * *"
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -11,7 +11,7 @@
 <p align="center">L'agent de codage IA open source.</p>
 <p align="center">
   <a href="https://github.com/Rwanbt/unifia/releases"><img alt="Releases" src="https://img.shields.io/github/v/release/Rwanbt/unifia?display_name=tag&style=flat-square" /></a>
-  <a href="https://github.com/Rwanbt/unifia/actions/workflows/fork-release.yml"><img alt="Build status" src="https://img.shields.io/github/actions/workflow/status/Rwanbt/unifia/fork-release.yml?style=flat-square&branch=main" /></a>
+  <a href="https://github.com/Rwanbt/unifia/actions/workflows/release.yml"><img alt="Build status" src="https://img.shields.io/github/actions/workflow/status/Rwanbt/unifia/release.yml?style=flat-square&branch=main" /></a>
 </p>
 
 <p align="center">

--- a/install
+++ b/install
@@ -5,7 +5,7 @@ APP=unifia
 # Where releases are fetched from. This used to be anomalyco/opencode — the
 # upstream project — so a plain `./install` downloaded OpenCode and wrote it
 # over the user's own OpenCode binary. The fork publishes to its own repository
-# (see the `github.repository` guards in .github/workflows/fork-release.yml);
+# (see the `github.repository` guards in .github/workflows/release.yml);
 # overridable so the eventual repository rename is one variable, not five URLs.
 UNIFIA_RELEASE_REPO=${UNIFIA_RELEASE_REPO:-Rwanbt/unifia}
 

--- a/packages/app/e2e/commands/tab-close.spec.ts
+++ b/packages/app/e2e/commands/tab-close.spec.ts
@@ -17,7 +17,7 @@ test("mod+w closes the active file tab", async ({ page, gotoSession }) => {
   await expect(dialog).toBeVisible()
 
   await dialog.getByRole("textbox").first().fill("package.json")
-  const item = dialog.locator('[data-slot="list-item"][data-key^="file:"]').first()
+  const item = dialog.locator('[data-slot="list-item"][data-key="file:package.json"]')
   await expect(item).toBeVisible({ timeout: 30_000 })
   await item.click()
   await expect(dialog).toHaveCount(0)

--- a/packages/desktop/scripts/utils.ts
+++ b/packages/desktop/scripts/utils.ts
@@ -35,7 +35,7 @@ export function getCurrentSidecar(target = RUST_TARGET) {
 
 // The official release matrix cross-compiles a "-baseline" CLI variant
 // (older CPU instruction sets) for x64 targets. Pipelines that only build
-// the host's native target (e.g. fork-release.yml) never produce that
+// the host's native target (e.g. release.yml) never produce that
 // directory, so fall back to the plain binary — same resilience already
 // used by copy-sidecar.ts's candidate list.
 export async function resolveSidecarBinaryPath(dir: string, ocBinary: string) {

--- a/packages/unifia/src/installation/index.ts
+++ b/packages/unifia/src/installation/index.ts
@@ -14,7 +14,7 @@ import { CHANNEL as channel, VERSION as version } from "./meta"
 import semver from "semver"
 
 // This fork publishes its own releases (tags `v<semver>-fork[.N]`, see
-// .github/workflows/fork-release.yml) instead of anomalyco/opencode's. Update
+// .github/workflows/release.yml) instead of anomalyco/opencode's. Update
 // checks must compare against this repo, or every install looks perpetually
 // out of date against upstream's own (unrelated) version numbering.
 const FORK_REPO = "Rwanbt/unifia"
@@ -25,7 +25,7 @@ const FORK_REPO = "Rwanbt/unifia"
 // compared this fork against a version line that is not its own.
 const NPM_PACKAGE = "unifia-ai"
 
-// Shipped as a release asset by .github/workflows/fork-release.yml, so the
+// Shipped as a release asset by .github/workflows/release.yml, so the
 // installer the upgrade path runs is the one this repo builds.
 const INSTALL_SCRIPT_URL = `https://github.com/${FORK_REPO}/releases/latest/download/install`
 

--- a/script/publish.ts
+++ b/script/publish.ts
@@ -9,11 +9,11 @@ import { fileURLToPath } from "url"
 // not own. Unreachable here by workflow gating (.github/workflows/publish.yml
 // runs only on `anomalyco/opencode`), and kept byte-compatible so the monthly
 // upstream sync stays conflict-free — but a manual run would still fire.
-// Unifia releases through .github/workflows/fork-release.yml.
+// Unifia releases through .github/workflows/release.yml.
 if (!process.env["UNIFIA_ALLOW_UPSTREAM_PUBLISH"]) {
   throw new Error(
     "script/publish.ts is upstream's release path and pushes to infrastructure this fork does not own. " +
-      "Unifia releases via .github/workflows/fork-release.yml; npm alone via packages/unifia/script/publish-npm.ts.",
+      "Unifia releases via .github/workflows/release.yml; npm alone via packages/unifia/script/publish-npm.ts.",
   )
 }
 

--- a/scripts/bundle-mobile.mjs
+++ b/scripts/bundle-mobile.mjs
@@ -26,7 +26,7 @@ const outdir = process.argv.includes("--outdir")
 
 const assetsDir = join(ROOT, "packages/mobile/src-tauri/gen/android/app/src/main/assets/runtime")
 // The release workflows export UNIFIA_VERSION / UNIFIA_CHANNEL (publish.yml,
-// fork-release.yml). Reading only the OPENCODE_* names made every Android build
+// release.yml). Reading only the OPENCODE_* names made every Android build
 // fall back to "local", so the app reported no version at all. The old names
 // stay as a fallback for anyone invoking this script with the pre-rebrand env.
 const runtimeVersion = process.env.UNIFIA_VERSION || process.env.OPENCODE_VERSION || "local"


### PR DESCRIPTION
### Issue for this PR

Closes #30

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Repairs seven stale references to fork-release.yml after the workflow was renamed to release.yml. This restores the French README badge and the publish error guidance while preserving the dated historical references that intentionally document the rename. The PR also makes the tab-close E2E deterministic by selecting the requested package.json result instead of the first file result.

### How did you verify your code works?

Typecheck passed for all 35 packages on push. The targeted tab-close E2E test passed locally (1/1), and GitHub checks on the previous run passed; checks are rerunning for this update.

### Screenshots / recordings

Not a UI change; no screenshot required.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR