### PR TITLE
feat(a2-01): v110 shell frame, topbar, rail

### DIFF
--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -162,8 +162,9 @@ export function Titlebar() {
 
   return (
     <header
-      class="h-10 shrink-0 bg-background-base relative grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center"
-      style={{ "min-height": minHeight() }}
+      data-component="v110-topbar"
+      class="shrink-0 bg-background-base relative grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center"
+      style={{ height: "var(--v110-topbar, 48px)", "min-height": minHeight() }}
       data-tauri-drag-region
       onMouseDown={drag}
       onDblClick={maximize}

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1003,7 +1003,7 @@ export default function Layout(props: ParentProps) {
 
   return (
     <TitlebarSlotsProvider>
-      <div class="relative bg-background-base flex-1 min-h-0 min-w-0 flex flex-col select-none [&_input]:select-text [&_textarea]:select-text [&_[contenteditable]]:select-text">
+      <div data-v110="shell-frame" data-component="v110-shell-frame" class="relative bg-background-base flex-1 min-h-0 min-w-0 flex flex-col select-none [&_input]:select-text [&_textarea]:select-text [&_[contenteditable]]:select-text">
       <Titlebar />
       <WorkspaceTabsBar />
       <div class="flex-1 min-h-0 min-w-0 flex">
@@ -1057,13 +1057,13 @@ export default function Layout(props: ParentProps) {
 
             <div
               class="hidden xl:block pointer-events-none absolute top-0 right-0 z-0 border-t border-border-weaker-base"
-              style={{ left: "calc(4rem + 12px)" }}
+              style={{ left: "calc(var(--v110-rail, 78px) + 12px)" }}
             />
 
             <div class="xl:hidden">
               <div
                 classList={{
-                  "fixed inset-x-0 top-10 bottom-0 z-40 transition-opacity duration-200": true,
+                  "fixed inset-x-0 top-12 bottom-0 z-40 transition-opacity duration-200": true,
                   "opacity-100 pointer-events-auto": layout.mobileSidebar.opened(),
                   "opacity-0 pointer-events-none": !layout.mobileSidebar.opened(),
                 }}
@@ -1075,7 +1075,7 @@ export default function Layout(props: ParentProps) {
                 aria-label={language.t("sidebar.nav.projectsAndSessions")}
                 data-component="sidebar-nav-mobile"
                 classList={{
-                  "@container fixed top-10 bottom-0 left-0 z-50 w-full max-w-[400px] overflow-hidden border-r border-border-weaker-base bg-background-base transition-transform duration-200 ease-out": true,
+                  "@container fixed top-12 bottom-0 left-0 z-50 w-full max-w-[400px] overflow-hidden border-r border-border-weaker-base bg-background-base transition-transform duration-200 ease-out": true,
                   "translate-x-0": layout.mobileSidebar.opened(),
                   "-translate-x-full": !layout.mobileSidebar.opened(),
                 }}
@@ -1094,10 +1094,11 @@ export default function Layout(props: ParentProps) {
                   !state.sizing,
               }}
               style={{
-                "--main-left": layout.sidebar.opened() ? `${side()}px` : "4rem",
+                "--main-left": layout.sidebar.opened() ? `${side()}px` : "var(--v110-rail, 78px)",
               }}
             >
               <main
+                data-v110="workspace"
                 data-workbench-mode={mode.active()}
                 classList={{
                   "size-full overflow-x-hidden flex flex-col items-start contain-strict border-t border-border-weak-base bg-background-base xl:border-l xl:rounded-tl-[12px]": true,
@@ -1111,7 +1112,7 @@ export default function Layout(props: ParentProps) {
 
             <div
               classList={{
-                "hidden xl:flex absolute inset-y-0 left-16 z-30": true,
+                "hidden xl:flex absolute inset-y-0 z-30 left-[var(--v110-rail,78px)]": true,
                 "opacity-100 translate-x-0 pointer-events-auto": state.peeked && !layout.sidebar.opened(),
                 "opacity-0 -translate-x-2 pointer-events-none": !state.peeked || layout.sidebar.opened(),
                 "transition-[opacity,transform] motion-reduce:transition-none": true,
@@ -1142,7 +1143,7 @@ export default function Layout(props: ParentProps) {
                 "duration-180 ease-out": state.peeked && !layout.sidebar.opened(),
                 "duration-120 ease-in": !state.peeked || layout.sidebar.opened(),
               }}
-              style={{ left: `calc(4rem + ${panel()}px)` }}
+              style={{ left: `calc(var(--v110-rail, 78px) + ${panel()}px)` }}
             >
               <div class="h-full w-px" style={{ "box-shadow": "var(--shadow-sidebar-overlay)" }} />
             </div>

--- a/packages/app/src/pages/layout/sidebar-shell.tsx
+++ b/packages/app/src/pages/layout/sidebar-shell.tsx
@@ -57,7 +57,9 @@ export const SidebarContent = (props: {
     <div class="flex h-full w-full min-w-0 overflow-hidden">
       <div
         data-component="sidebar-rail"
-        class="w-16 shrink-0 bg-background-base flex flex-col items-center overflow-hidden"
+        data-v110="rail"
+        class="shrink-0 bg-background-base flex flex-col items-center overflow-hidden"
+        style={{ width: "var(--v110-rail, 78px)" }}
         onMouseMove={props.aimMove}
       >
         <div class="flex-1 min-h-0 w-full">

--- a/packages/app/src/shell/v110-store.test.ts
+++ b/packages/app/src/shell/v110-store.test.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+import { describe, expect, test } from "bun:test"
+import { shown } from "@/shell/v110-store"
+import { SHELL_MODES } from "@unifia/workbench-shell/modes"
+import { AUTOMATE_CAPABILITY, isAutomateAccessible } from "@/context/automate-flag"
+describe("a2 shell store", () => {
+  test("registry stays 4 modes (GAP-02)", () => {
+    expect([...SHELL_MODES]).toEqual(["code", "work", "design", "automate"])
+  })
+  test("automate gate stays workflow.run (GAP-03)", () => {
+    expect(AUTOMATE_CAPABILITY).toBe("workflow.run")
+    expect(isAutomateAccessible(new Set(["workflow.run"]))).toBe(true)
+    expect(isAutomateAccessible(new Set([]))).toBe(false)
+  })
+  test("panel visibility follows the A1 invariant", () => {
+    expect(shown(["context", "inspector"], "desktop-wide")).toEqual(["context", "inspector"])
+    expect(shown(["context", "inspector"], "desktop-compact")).toEqual(["inspector"])
+    expect(shown(["inspector", "context"], "desktop-compact")).toEqual(["context"])
+    expect(shown(["context"], "phone-portrait")).toEqual(["context"])
+  })
+})

--- a/packages/app/src/shell/v110-store.ts
+++ b/packages/app/src/shell/v110-store.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+// A2-01 shell responsive adapter (Wave 0.5).
+// WHY thin adapter next to tokens/viewport: tokens own the pure contract
+// (classify/side/layouts, 1200/900/600 + landscape h<=560&w<=980).
+// This module owns reactive wiring (window size -> viewport) only.
+// Panel open state stays in context/layout (sidebar/fileTree/review,
+// persistes layout.v6): no second panel store.
+// Legacy 768/1024 (use-mobile-layout, design-responsive) documented in
+// shell/v110-viewport (A2-03); shell reads only classify.
+// Registry GAP-02: SHELL_MODES = code/work/design/automate (4). Browser,
+// memory, settings, user are destinations, not modes: rail renders
+// mode.modes (already automate-gated) + settings/user below, never 10.
+// Automate GAP-03: single gate isAutomateAccessible on workflow.run via
+// context/mode visibleModes. Browser GAP-01: shell only, no fake browser:
+// DesignBrowserTab drives a real Tauri WebView (invoke), shell adds none.
+// Inspector: shell owns frame (A2-02), modes own content; FileTree stays
+// the single instance inside the inspector (session-side-panel).
+import { createMemo, createSignal, onCleanup, onMount, type Accessor } from "solid-js"
+import { classify, cohabit, exclusive, layouts, side, type Layout, type Viewport } from "@/tokens/viewport"
+import { visible, type Panel } from "@/tokens/panels"
+export type { Layout, Viewport }
+type Size = { width: number; height: number }
+function read(): Size {
+  if (typeof window === "undefined") return { width: 1440, height: 900 }
+  return { width: window.innerWidth, height: window.innerHeight }
+}
+// Reactive viewport id. Single responsive authority for the shell.
+export function useViewport(): Accessor<Viewport> {
+  const [size, setSize] = createSignal<Size>(read(), { equals: false })
+  onMount(() => {
+    const sync = () => setSize(read())
+    window.addEventListener("resize", sync)
+    window.addEventListener("orientationchange", sync)
+    onCleanup(() => {
+      window.removeEventListener("resize", sync)
+      window.removeEventListener("orientationchange", sync)
+    })
+  })
+  return createMemo(() => classify(size().width, size().height))
+}
+// Visible panels for one viewport (desktop-wide cohabits, desktop-compact
+// keeps last opened, overlays render the stack last-on-top).
+export function shown(open: Panel[], id: Viewport): Panel[] {
+  return visible(open, id)
+}
+export function useShell(id: Accessor<Viewport>) {
+  const kind = createMemo(() => side(id()))
+  const modes = createMemo(() => layouts(id()))
+  const wide = createMemo(() => cohabit(id()))
+  const single = createMemo(() => exclusive(id()))
+  return { kind, modes, wide, single }
+}


### PR DESCRIPTION
Part of Wave 0.5 (A2 Shell), stacked as A2-01/02/03 per docs/ui-reference/v110/PLAN-8-AGENTS.md and OWNERSHIP.md.

Base: feat/ui-v110-port @ fae99a72 (A1 Foundation, already integrated — feat/ui-v110-port is the same commit as ui-v110/a1-foundation).

Scope (A2-01 only):
- packages/app/src/shell/v110-store.ts (+test): shell mode/panel state store on A1 tokens.
- packages/app/src/pages/layout.tsx, layout/sidebar-shell.tsx: wire v110 frame/topbar/rail 4 modes onto the existing layout.

Ownership: topbar/rail/layout switch per OWNERSHIP.md A2 WRITE-exclusive list. No modification to session.tsx, mode.tsx, global-sync, or design tokens.

Gate: bun typecheck green (47/47 packages, verified via repo pre-push hook). Old surfaces stay mounted; no runtime removed.

Stacked on top of this PR: A2-02 (context/inspector panels), A2-03 (responsive/mobile nav).