### PR TITLE
feat(a2-02): v110 context and inspector panels

### DIFF
--- a/packages/app/src/i18n/ar.ts
+++ b/packages/app/src/i18n/ar.ts
@@ -560,6 +560,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "المشاريع والجلسات",
   "sidebar.settings": "الإعدادات",
   "sidebar.help": "مساعدة",
+  "sidebar.resize": "تغيير حجم الشريط الجانبي",
+  "inspector.resize": "تغيير حجم لوحة الفحص",
   "sidebar.workspaces.enable": "تمكين مساحات العمل",
   "sidebar.workspaces.disable": "تعطيل مساحات العمل",
   "sidebar.gettingStarted.title": "البدء",

--- a/packages/app/src/i18n/br.ts
+++ b/packages/app/src/i18n/br.ts
@@ -567,6 +567,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "Projetos e sessões",
   "sidebar.settings": "Configurações",
   "sidebar.help": "Ajuda",
+  "sidebar.resize": "Redimensionar a barra lateral",
+  "inspector.resize": "Redimensionar o inspetor",
   "sidebar.workspaces.enable": "Habilitar espaços de trabalho",
   "sidebar.workspaces.disable": "Desabilitar espaços de trabalho",
   "sidebar.gettingStarted.title": "Começando",

--- a/packages/app/src/i18n/bs.ts
+++ b/packages/app/src/i18n/bs.ts
@@ -628,6 +628,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "Projekti i sesije",
   "sidebar.settings": "Postavke",
   "sidebar.help": "Pomoć",
+  "sidebar.resize": "Promijeni veličinu bočne trake",
+  "inspector.resize": "Promijeni veličinu inspektora",
   "sidebar.workspaces.enable": "Omogući radne prostore",
   "sidebar.workspaces.disable": "Onemogući radne prostore",
   "sidebar.gettingStarted.title": "Početak",

--- a/packages/app/src/i18n/da.ts
+++ b/packages/app/src/i18n/da.ts
@@ -624,6 +624,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "Projekter og sessioner",
   "sidebar.settings": "Indstillinger",
   "sidebar.help": "Hjælp",
+  "sidebar.resize": "Tilpas sidepanelets bredde",
+  "inspector.resize": "Tilpas inspektørens bredde",
   "sidebar.workspaces.enable": "Aktiver arbejdsområder",
   "sidebar.workspaces.disable": "Deaktiver arbejdsområder",
   "sidebar.gettingStarted.title": "Kom i gang",

--- a/packages/app/src/i18n/de.ts
+++ b/packages/app/src/i18n/de.ts
@@ -575,6 +575,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "Projekte und Sitzungen",
   "sidebar.settings": "Einstellungen",
   "sidebar.help": "Hilfe",
+  "sidebar.resize": "Seitenleiste anpassen",
+  "inspector.resize": "Inspektor anpassen",
   "sidebar.workspaces.enable": "Arbeitsbereiche aktivieren",
   "sidebar.workspaces.disable": "Arbeitsbereiche deaktivieren",
   "sidebar.gettingStarted.title": "Erste Schritte",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -717,6 +717,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "Projects and sessions",
   "sidebar.settings": "Settings",
   "sidebar.help": "Help",
+  "sidebar.resize": "Resize sidebar",
+  "inspector.resize": "Resize inspector",
   "sidebar.workspaces.enable": "Enable workspaces",
   "sidebar.workspaces.disable": "Disable workspaces",
   "sidebar.gettingStarted.title": "Getting started",

--- a/packages/app/src/i18n/es.ts
+++ b/packages/app/src/i18n/es.ts
@@ -568,6 +568,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "Proyectos y sesiones",
   "sidebar.settings": "Ajustes",
   "sidebar.help": "Ayuda",
+  "sidebar.resize": "Redimensionar la barra lateral",
+  "inspector.resize": "Redimensionar el inspector",
   "sidebar.workspaces.enable": "Habilitar espacios de trabajo",
   "sidebar.workspaces.disable": "Deshabilitar espacios de trabajo",
   "sidebar.gettingStarted.title": "Empezando",

--- a/packages/app/src/i18n/fr.ts
+++ b/packages/app/src/i18n/fr.ts
@@ -589,6 +589,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "Projets et sessions",
   "sidebar.settings": "Paramètres",
   "sidebar.help": "Aide",
+  "sidebar.resize": "Redimensionner la barre latérale",
+  "inspector.resize": "Redimensionner l'inspecteur",
   "sidebar.workspaces.enable": "Activer les espaces de travail",
   "sidebar.workspaces.disable": "Désactiver les espaces de travail",
   "sidebar.gettingStarted.title": "Commencer",

--- a/packages/app/src/i18n/ja.ts
+++ b/packages/app/src/i18n/ja.ts
@@ -564,6 +564,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "プロジェクトとセッション",
   "sidebar.settings": "設定",
   "sidebar.help": "ヘルプ",
+  "sidebar.resize": "サイドバーの幅を変更",
+  "inspector.resize": "インスペクターの幅を変更",
   "sidebar.workspaces.enable": "ワークスペースを有効化",
   "sidebar.workspaces.disable": "ワークスペースを無効化",
   "sidebar.gettingStarted.title": "はじめに",

--- a/packages/app/src/i18n/ko.ts
+++ b/packages/app/src/i18n/ko.ts
@@ -566,6 +566,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "프로젝트 및 세션",
   "sidebar.settings": "설정",
   "sidebar.help": "도움말",
+  "sidebar.resize": "사이드바 크기 조정",
+  "inspector.resize": "인스펙터 크기 조정",
   "sidebar.workspaces.enable": "작업 공간 활성화",
   "sidebar.workspaces.disable": "작업 공간 비활성화",
   "sidebar.gettingStarted.title": "시작하기",

--- a/packages/app/src/i18n/no.ts
+++ b/packages/app/src/i18n/no.ts
@@ -567,6 +567,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "Prosjekter og sesjoner",
   "sidebar.settings": "Innstillinger",
   "sidebar.help": "Hjelp",
+  "sidebar.resize": "Endre størrelse på sidepanelet",
+  "inspector.resize": "Endre størrelse på inspektøren",
   "sidebar.workspaces.enable": "Aktiver arbeidsområder",
   "sidebar.workspaces.disable": "Deaktiver arbeidsområder",
   "sidebar.gettingStarted.title": "Kom i gang",

--- a/packages/app/src/i18n/pl.ts
+++ b/packages/app/src/i18n/pl.ts
@@ -565,6 +565,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "Projekty i sesje",
   "sidebar.settings": "Ustawienia",
   "sidebar.help": "Pomoc",
+  "sidebar.resize": "Zmień szerokość paska bocznego",
+  "inspector.resize": "Zmień szerokość inspektora",
   "sidebar.workspaces.enable": "Włącz przestrzenie robocze",
   "sidebar.workspaces.disable": "Wyłącz przestrzenie robocze",
   "sidebar.gettingStarted.title": "Pierwsze kroki",

--- a/packages/app/src/i18n/ru.ts
+++ b/packages/app/src/i18n/ru.ts
@@ -569,6 +569,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "Проекты и сессии",
   "sidebar.settings": "Настройки",
   "sidebar.help": "Помощь",
+  "sidebar.resize": "Изменить ширину боковой панели",
+  "inspector.resize": "Изменить ширину инспектора",
   "sidebar.workspaces.enable": "Включить рабочие пространства",
   "sidebar.workspaces.disable": "Отключить рабочие пространства",
   "sidebar.gettingStarted.title": "Начало работы",

--- a/packages/app/src/i18n/th.ts
+++ b/packages/app/src/i18n/th.ts
@@ -622,6 +622,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "โปรเจกต์และเซสชัน",
   "sidebar.settings": "การตั้งค่า",
   "sidebar.help": "ช่วยเหลือ",
+  "sidebar.resize": "ปรับขนาดแถบด้านข้าง",
+  "inspector.resize": "ปรับขนาดแผงตรวจสอบ",
   "sidebar.workspaces.enable": "เปิดใช้งานพื้นที่ทำงาน",
   "sidebar.workspaces.disable": "ปิดใช้งานพื้นที่ทำงาน",
   "sidebar.gettingStarted.title": "เริ่มต้นใช้งาน",

--- a/packages/app/src/i18n/tr.ts
+++ b/packages/app/src/i18n/tr.ts
@@ -569,6 +569,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "Projeler ve oturumlar",
   "sidebar.settings": "Ayarlar",
   "sidebar.help": "Yardım",
+  "sidebar.resize": "Kenar çubuğunu yeniden boyutlandır",
+  "inspector.resize": "Denetçiyi yeniden boyutlandır",
   "sidebar.workspaces.enable": "Çalışma alanlarını etkinleştir",
   "sidebar.workspaces.disable": "Çalışma alanlarını devre dışı bırak",
   "sidebar.gettingStarted.title": "Başlarken",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -621,6 +621,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "项目和会话",
   "sidebar.settings": "设置",
   "sidebar.help": "帮助",
+  "sidebar.resize": "调整侧边栏宽度",
+  "inspector.resize": "调整检查器宽度",
   "sidebar.workspaces.enable": "启用工作区",
   "sidebar.workspaces.disable": "禁用工作区",
   "sidebar.gettingStarted.title": "入门",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -618,6 +618,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "專案與工作階段",
   "sidebar.settings": "設定",
   "sidebar.help": "說明",
+  "sidebar.resize": "調整側邊欄寬度",
+  "inspector.resize": "調整檢查器寬度",
   "sidebar.workspaces.enable": "啟用工作區",
   "sidebar.workspaces.disable": "停用工作區",
   "sidebar.gettingStarted.title": "開始使用",

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -15,7 +15,7 @@ import { useLayout, type LocalProject } from "@/context/layout"
 import { useGlobalSync } from "@/context/global-sync"
 import { Persist, persisted } from "@/utils/persist"
 import { decode64 } from "@/utils/base64"
-import { ResizeHandle } from "@unifia/ui/resize-handle"
+import { Separator } from "@/primitives/separator"
 import type { Session } from "../types/sdk-shim"
 import { usePlatform } from "@/context/platform"
 import { useSettings } from "@/context/settings"
@@ -1040,8 +1040,10 @@ export default function Layout(props: ParentProps) {
                 style={{ left: `${side()}px` }}
                 onPointerDown={() => setState("sizing", true)}
               >
-                <ResizeHandle
-                  direction="horizontal"
+                <Separator
+                  axis="x"
+                  label={language.t("sidebar.resize")}
+                  data-v110="resize-context"
                   size={layout.sidebar.width()}
                   min={244}
                   max={typeof window === "undefined" ? 1000 : window.innerWidth * 0.3 + 64}

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -4,7 +4,7 @@ import { createMediaQuery } from "@solid-primitives/media"
 import { Tabs } from "@unifia/ui/tabs"
 import { IconButton } from "@unifia/ui/icon-button"
 import { TooltipKeybind } from "@unifia/ui/tooltip"
-import { ResizeHandle } from "@unifia/ui/resize-handle"
+import { Separator } from "@/primitives/separator"
 import { Mark } from "@unifia/ui/logo"
 import { DragDropProvider, DragDropSensors, DragOverlay, SortableProvider, closestCenter } from "@thisbeyond/solid-dnd"
 import type { DragEvent } from "@thisbeyond/solid-dnd"
@@ -284,7 +284,10 @@ export function SessionSidePanel(props: {
   })
 
   return (
+    // Shell owns the inspector frame (A2), modes own content (A3+): this
+    // aside stays the single inspector content (no second FileTree).
     <aside
+        data-v110="inspector-content"
         id="review-panel"
         aria-label={language.t("session.panel.reviewAndFiles")}
         aria-hidden={!open()}
@@ -654,9 +657,11 @@ export function SessionSidePanel(props: {
             </div>
             <Show when={fileOpen()}>
               <div onPointerDown={() => props.size.start()}>
-                <ResizeHandle
-                  direction="horizontal"
+                <Separator
+                  axis="x"
                   edge="start"
+                  label={language.t("inspector.resize")}
+                  data-v110="resize-inspector"
                   size={layout.fileTree.width()}
                   min={200}
                   max={480}

--- a/packages/app/src/shell/v110-inspector-frame.test.ts
+++ b/packages/app/src/shell/v110-inspector-frame.test.ts
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: MIT */
+
+import { describe, expect, test } from "bun:test"
+import { readFile } from "node:fs/promises"
+import { TABS, normalizeTab } from "@/shell/v110-inspector-frame"
+
+describe("a2 inspector frame", () => {
+  test("tabs stay Explorer, Inspector, Execution (INTERACTIONS.md)", () => {
+    expect([...TABS]).toEqual(["explorer", "inspector", "execution"])
+  })
+  test("unknown tabs fall back to explorer", () => {
+    expect(normalizeTab(undefined)).toBe("explorer")
+    expect(normalizeTab("graph")).toBe("explorer")
+    expect(normalizeTab("inspector")).toBe("inspector")
+    expect(normalizeTab("execution")).toBe("execution")
+  })
+  test("frame owns structure only: no app runtime import (P1-2, P1-3)", async () => {
+    const src = await readFile(new URL("./v110-inspector-frame.tsx", import.meta.url), "utf8")
+    expect(src.includes("@/")).toBe(false)
+    expect(src.includes("@unifia/workbench-shell")).toBe(false)
+  })
+})

--- a/packages/app/src/shell/v110-inspector-frame.tsx
+++ b/packages/app/src/shell/v110-inspector-frame.tsx
@@ -1,0 +1,75 @@
+/* SPDX-License-Identifier: MIT */
+
+// A2-02 v110 inspector frame (Wave 0.5). Frame only, never content.
+// WHY frame-only: COMPONENT-MAP 1 gives the shell ONE structural inspector
+// authority (frame plus tabs), modes own content (A3 and later). The file
+// explorer stays the single instance inside the session inspector content
+// (data-v110 inspector-content): this file owns structure, never content.
+// Tabs Explorer plus Inspector plus Execution mirror INTERACTIONS.md. Graph
+// Memory stays a Memory sub-view, never a global tab. Sizes come from A1
+// vars (v110-inspector). Open state stays owned by callers and persisted in
+// context/layout (layout.v6): the frame is controlled, stores nothing.
+// Not mounted yet: A3 branches mode content onto it. Mounting now would
+// render a second inspector next to the session panel (P1-2).
+
+import { For, type JSX } from "solid-js"
+
+export const TABS = ["explorer", "inspector", "execution"] as const
+export type Tab = (typeof TABS)[number]
+
+export function normalizeTab(value: string | undefined): Tab {
+  if (value === "inspector") return "inspector"
+  if (value === "execution") return "execution"
+  return "explorer"
+}
+
+type Props = {
+  tab: Tab
+  onTab: (tab: Tab) => void
+  open: boolean
+  onToggle: () => void
+  label: string
+  title: (tab: Tab) => string
+  children: JSX.Element
+}
+
+export function InspectorFrame(props: Props): JSX.Element {
+  const current = () => normalizeTab(props.tab)
+  return (
+    <aside
+      data-v110="inspector-frame"
+      data-component="v110-inspector-frame"
+      role="complementary"
+      aria-label={props.label}
+      style={{ width: "var(--v110-inspector, 300px)" }}
+    >
+      <div role="tablist" aria-label={props.label} data-v110="inspector-tabs">
+        <For each={TABS}>
+          {(tab) => (
+            <button
+              type="button"
+              role="tab"
+              aria-selected={current() === tab}
+              data-v110-tab={tab}
+              onClick={() => props.onTab(tab)}
+            >
+              {props.title(tab)}
+            </button>
+          )}
+        </For>
+        <button
+          type="button"
+          aria-expanded={props.open}
+          aria-controls="v110-inspector-panel"
+          data-action="inspector-toggle"
+          onClick={props.onToggle}
+        >
+          {props.open ? "\u2013" : "+"}
+        </button>
+      </div>
+      <div id="v110-inspector-panel" role="tabpanel" hidden={!props.open}>
+        {props.children}
+      </div>
+    </aside>
+  )
+}


### PR DESCRIPTION
Stacked on #63 (A2-01). Part of Wave 0.5 (A2 Shell).

Scope (A2-02 only):
- packages/app/src/shell/v110-inspector-frame.tsx (+test): inspector shell frame (structure only, not content).
- packages/app/src/pages/layout.tsx, pages/session/session-side-panel.tsx: context/inspector panels on the Separator primitive.

Ownership: inspector shell (frame only) + context panel per OWNERSHIP.md A2 WRITE-exclusive list. Content injection stays with the mode owners (A3-A7), not implemented here. No second Inspector authority created.

Gate: bun typecheck green (47/47 packages).