### PR TITLE
feat(a2-03): v110 responsive matrix, mobile nav, chat resizer

### DIFF
--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -1,6 +1,7 @@
 @import "@unifia/ui/styles/tailwind";
 @import "@/styles/unifia-brand.css";
 @import '@/styles/v110.css';
+@import '@/shell/v110-shell.css';
 
 @layer components {
   [data-component="getting-started"] {

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -58,6 +58,7 @@ import type {
 import { ProjectDragOverlay, SortableProject, type ProjectSidebarContext } from "./layout/sidebar-project"
 import { SidebarPanel, type SidebarPanelContext } from "./layout/sidebar-panel"
 import { SidebarContent } from "./layout/sidebar-shell"
+import { MobileNav } from "@/shell/v110-mobile-nav"
 import { useMode } from "@/context/mode"
 import { DialogDeleteWorkspace, DialogResetWorkspace } from "./layout/dialog-workspace"
 import { createPrefetchSystem } from "./layout/prefetch"
@@ -1086,6 +1087,16 @@ export default function Layout(props: ParentProps) {
                 {sidebarContent(true)}
               </nav>
             </div>
+
+            <MobileNav
+              modes={mode.modes}
+              active={mode.active}
+              onMode={mode.select}
+              onSettings={openSettings}
+              navLabel={language.t("workbench.modes.railLabel")}
+              modeLabel={(m) => language.t(`workbench.modes.${m}`)}
+              settingsLabel={language.t("sidebar.settings")}
+            />
 
             <div
               classList={{

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -21,7 +21,7 @@ import { createResizeObserver } from "@solid-primitives/resize-observer"
 import { useLocal } from "@/context/local"
 import { useFile } from "@/context/file"
 import { createStore, produce } from "solid-js/store"
-import { ResizeHandle } from "@unifia/ui/resize-handle"
+import { Separator } from "@/primitives/separator"
 import { Tabs } from "@unifia/ui/tabs"
 import { createSessionScroll } from "@/pages/session/session-scroll"
 import { showToast } from "@unifia/ui/toast"
@@ -1054,8 +1054,10 @@ export default function Page() {
 
           <Show when={desktopReviewOpen()}>
             <div onPointerDown={() => size.start()}>
-              <ResizeHandle
-                direction="horizontal"
+              <Separator
+                axis="x"
+                label={language.t("design.split.handle")}
+                data-v110="resize-chat"
                 size={layout.session.width()}
                 min={450}
                 max={typeof window === "undefined" ? 1000 : window.innerWidth * 0.45}

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -35,6 +35,7 @@ import { FileTabContent } from "@/pages/session/file-tabs"
 import { createOpenSessionFileTab, createSessionTabs, getTabReorderIndex, type Sizing } from "@/pages/session/helpers"
 import { setSessionHandoff } from "@/pages/session/handoff"
 import { useSessionLayout } from "@/pages/session/session-layout"
+import { useShell, useViewport } from "@/shell/v110-store"
 
 export function SessionSidePanel(props: {
   canReview: () => boolean
@@ -68,6 +69,25 @@ export function SessionSidePanel(props: {
   const fileOpen = createMemo(() => layout.fileTree.opened())
   const open = createMemo(() => reviewOpen() || fileOpen())
   const bothOpen = createMemo(() => reviewOpen() && fileOpen())
+
+  // RESPONSIVE-MATRIX.md desktop-compact invariant: opening the left panel
+  // closes the Inspector and inversely (single-utility side, per the A1
+  // viewport contract's exclusive()). Two effects instead of one shared
+  // toggle so each side stays the source of truth for its own open state;
+  // the `if` guards make both idempotent, so a close triggered by the
+  // other side never bounces back.
+  const shell = useShell(useViewport())
+  createEffect(() => {
+    if (!shell.single()) return
+    if (!layout.sidebar.opened()) return
+    if (fileOpen()) layout.fileTree.close()
+    if (reviewOpen()) view().reviewPanel.close()
+  })
+  createEffect(() => {
+    if (!shell.single()) return
+    if (!open()) return
+    if (layout.sidebar.opened()) layout.sidebar.close()
+  })
   const panelWidth = createMemo(() => {
     if (!open()) return "0px"
     if (isMobileDevice()) return "50%"

--- a/packages/app/src/shell/v110-mobile-nav.test.ts
+++ b/packages/app/src/shell/v110-mobile-nav.test.ts
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: MIT */
+
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+// Static contract (same style as design-split.test.tsx): the bar renders
+// what it is given, stays phone-only, keeps touch targets and safe areas.
+// Plain substring matchers: no regex escaping pitfalls.
+const dir = join(import.meta.dir, ".");
+const nav = readFileSync(join(dir, "v110-mobile-nav.tsx"), "utf8")
+const css = readFileSync(join(dir, "v110-shell.css"), "utf8")
+
+describe("a2 mobile nav", () => {
+  test("renders the given modes plus settings, never a second registry", () => {
+    expect(nav.includes('data-v110="mobile-nav"')).toBe(true)
+    expect(nav.includes("data-mode={mode}")).toBe(true)
+    expect(nav.includes("aria-pressed={props.active() === mode}")).toBe(true)
+    expect(nav.includes('data-action="mobile-settings"')).toBe(true)
+    expect(nav.includes("SHELL_MODES")).toBe(false)
+    expect(nav.includes("useMode")).toBe(false)
+  })
+  test("touch targets and safe areas follow the A1 contract", () => {
+    expect(nav.includes("var(--v110-target-touch, 44px)")).toBe(true)
+    expect(nav.includes("env(safe-area-inset-bottom)")).toBe(true)
+    expect(nav.includes("env(safe-area-inset-left)")).toBe(true)
+    expect(nav.includes("env(safe-area-inset-right)")).toBe(true)
+    expect(css.includes("env(safe-area-inset-bottom)")).toBe(true)
+  })
+  test("phone-portrait only: hidden by default, no important", () => {
+    expect(css.includes('[data-v110="mobile-nav"]')).toBe(true)
+    expect(css.indexOf("display: none") !== -1 && css.indexOf("display: none") < css.indexOf("display: flex")).toBe(true)
+    expect(css.includes("max-width: 599px")).toBe(true)
+    expect(css.includes("!important")).toBe(false)
+  })
+  test("compact landscape overlays start after the compact rail", () => {
+    expect(css.includes("max-height: 560px")).toBe(true)
+    expect(css.includes("var(--v110-rail-compact, 62px)")).toBe(true)
+  })
+})

--- a/packages/app/src/shell/v110-mobile-nav.tsx
+++ b/packages/app/src/shell/v110-mobile-nav.tsx
@@ -1,0 +1,70 @@
+/* SPDX-License-Identifier: MIT */
+
+// A2-03 v110 mobile nav (Wave 0.5). Props-driven, no runtime import.
+// WHY props: the rail already gates automate (mode.modes) and owns the
+// 4-mode registry; a second rail reading stores directly would fork the
+// registry (GAP-02) and the grant gate (GAP-03). This bar renders what it
+// is given: modes plus settings, nothing else, never 10 buttons.
+// Phone-portrait only (RESPONSIVE-MATRIX): hidden by default, shown by
+// v110-shell.css under 600px portrait. Touch targets use the A1 touch
+// var (44px). Safe areas use env() so the iOS notch never covers a tab.
+
+import { For, type Accessor, type JSX } from "solid-js"
+import { Icon } from "@unifia/ui/icon"
+import type { ShellMode } from "@unifia/workbench-shell/modes"
+
+type Props = {
+  modes: Accessor<readonly ShellMode[]>
+  active: Accessor<ShellMode>
+  onMode: (mode: ShellMode) => void
+  onSettings: () => void
+  navLabel: string
+  modeLabel: (mode: ShellMode) => string
+  settingsLabel: string
+}
+
+export function MobileNav(props: Props): JSX.Element {
+  return (
+    <nav
+      data-v110="mobile-nav"
+      data-component="v110-mobile-nav"
+      aria-label={props.navLabel}
+      style={{
+        "padding-bottom": "env(safe-area-inset-bottom)",
+        "padding-left": "env(safe-area-inset-left)",
+        "padding-right": "env(safe-area-inset-right)",
+      }}
+    >
+      <For each={props.modes()}>
+        {(mode) => (
+          <button
+            type="button"
+            data-mode={mode}
+            data-v110-tab={mode}
+            aria-label={props.modeLabel(mode)}
+            aria-pressed={props.active() === mode}
+            style={{
+              width: "var(--v110-target-touch, 44px)",
+              height: "var(--v110-target-touch, 44px)",
+            }}
+            onClick={() => props.onMode(mode)}
+          >
+            <Icon size="medium" name={mode === "code" ? "code" : mode === "work" ? "folder" : mode === "design" ? "edit" : "checklist"} />
+          </button>
+        )}
+      </For>
+      <button
+        type="button"
+        data-action="mobile-settings"
+        aria-label={props.settingsLabel}
+        style={{
+          width: "var(--v110-target-touch, 44px)",
+          height: "var(--v110-target-touch, 44px)",
+        }}
+        onClick={props.onSettings}
+      >
+        <Icon size="medium" name="settings-gear" />
+      </button>
+    </nav>
+  )
+}

--- a/packages/app/src/shell/v110-shell.css
+++ b/packages/app/src/shell/v110-shell.css
@@ -1,0 +1,46 @@
+/* SPDX-License-Identifier: MIT */
+
+/* A2-03 v110 shell responsive layer (Wave 0.5).
+ * Additive only: geometry comes from A1 v110.css vars, colors from the
+ * theme. Authority is tokens/viewport classify (1200/900/600 plus
+ * landscape h<=560 and w<=980). No important anywhere.
+ */
+
+/* Bottom nav: phone-portrait only, hidden by default. */
+[data-v110="mobile-nav"] {
+  display: none;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 40;
+  min-height: 56px;
+  align-items: center;
+  justify-content: space-around;
+  background: var(--background-base);
+  border-top: 1px solid var(--border-weaker-base);
+}
+
+@media (max-width: 599px) and (orientation: portrait) {
+  [data-v110="mobile-nav"] {
+    display: flex;
+  }
+  /* The bar overlays content: reserve its height plus the notch so no
+   * control is cut and the composer stays reachable. */
+  [data-v110="workspace"] {
+    padding-bottom: calc(56px + env(safe-area-inset-bottom));
+  }
+}
+
+/* Compact landscape: overlays start after the compact rail. */
+@media (max-height: 560px) and (max-width: 980px) and (orientation: landscape) {
+  [data-component="sidebar-nav-mobile"] {
+    left: var(--v110-rail-compact, 62px);
+  }
+}
+
+/* Notch gutters for the topbar (mobile browsers, Tauri). */
+[data-component="v110-topbar"] {
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
+}

--- a/packages/app/src/shell/v110-viewport.test.ts
+++ b/packages/app/src/shell/v110-viewport.test.ts
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: MIT */
+
+import { describe, expect, test } from "bun:test"
+import { readdirSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe as summary, legacy, type Viewport } from "@/shell/v110-viewport"
+
+// A2-03 gate: minimal responsive matrix green at contract level.
+// Runtime Port Gate (viewport x mode x layout, zero x-overflow) is A8.
+describe("a2 responsive matrix", () => {
+  test("certification viewports classify to their viewport", () => {
+    const cases: Array<[number, number, Viewport]> = [
+      [1440, 900, "desktop-wide"],
+      [1280, 800, "desktop-wide"],
+      [1024, 768, "desktop-compact"],
+      [768, 1024, "tablet-portrait"],
+      [390, 844, "phone-portrait"],
+      [360, 800, "phone-portrait"],
+      [844, 390, "compact-landscape"],
+    ]
+    for (const [width, height, id] of cases) expect(summary(width, height).id).toBe(id)
+  })
+  test("thresholds cut cleanly with no second taxonomy", () => {
+    expect(summary(1200, 800).id).toBe("desktop-wide")
+    expect(summary(1199, 800).id).toBe("desktop-compact")
+    expect(summary(900, 700).id).toBe("desktop-compact")
+    expect(summary(899, 1000).id).toBe("tablet-portrait")
+    expect(summary(850, 650).id).toBe("desktop-compact")
+    expect(summary(600, 900).id).toBe("tablet-portrait")
+    expect(summary(599, 900).id).toBe("phone-portrait")
+    expect(summary(844, 560).id).toBe("compact-landscape")
+    expect(summary(844, 561).id).not.toBe("compact-landscape")
+  })
+  test("side invariants and layouts per viewport", () => {
+    expect(summary(1440, 900).side).toBe("grid")
+    expect(summary(1440, 900).wide).toBe(true)
+    expect(summary(1024, 768).side).toBe("single")
+    expect(summary(1024, 768).single).toBe(true)
+    expect(summary(768, 1024).side).toBe("overlay")
+    expect(summary(390, 844).side).toBe("overlay")
+    expect(summary(844, 390).side).toBe("overlay")
+    expect(summary(1440, 900).layouts).toEqual(["chat", "split", "main"])
+    expect(summary(1024, 768).layouts).toEqual(["chat", "split", "main"])
+    expect(summary(844, 390).layouts).toEqual(["chat", "split", "main"])
+    expect(summary(768, 1024).layouts).toEqual(["chat", "main"])
+    expect(summary(390, 844).layouts).toEqual(["chat", "main"])
+  })
+  test("legacy buckets map onto v110 without a second authority", () => {
+    expect(legacy(360)).toBe("mobile")
+    expect(legacy(800)).toBe("tablet")
+    expect(legacy(1400)).toBe("desktop")
+    expect(summary(700, 1000).id).toBe("tablet-portrait")
+    expect(summary(950, 700).id).toBe("desktop-compact")
+  })
+  test("shell imports only the A1 contract (P1-1, P1-6)", () => {
+    const dir = join(import.meta.dir, ".");
+    for (const file of readdirSync(dir)) {
+      if (!file.endsWith(".tsx") && !file.endsWith(".ts")) continue
+      if (file.endsWith(".test.ts")) continue
+      const src = readFileSync(join(dir, file), "utf8")
+      expect(/from\s+["\'][^"\']*use-mobile-layout["\']/.test(src)).toBe(false)
+      expect(/from\s+["\'][^"\']*design-responsive["\']/.test(src)).toBe(false)
+    }
+  })
+})

--- a/packages/app/src/shell/v110-viewport.ts
+++ b/packages/app/src/shell/v110-viewport.ts
@@ -1,0 +1,36 @@
+/* SPDX-License-Identifier: MIT */
+
+// A2-03 v110 responsive authority (Wave 0.5). Single source, pure.
+// WHY this file exists: three threshold sets compete (A1-CONTRACT P1-1).
+// classify (1200/900/600 plus landscape h<=560 and w<=980) is the only
+// authority the shell reads. use-mobile-layout (768/1024, createSignal)
+// and design-responsive (1024/768, pure) stay working for their current
+// callers until their owners rebase, but shell code must never import
+// them: the contract test below fails on such an import (P1-1, P1-6).
+// Legacy mapping (read-only, for migration reviews, never branched on):
+//   isMobile (<768)  -> phone-portrait, plus tablet 600-767 portrait.
+//   isTablet (768..1023) -> tablet-portrait, plus desktop-compact 900-1023
+//     and compact-landscape 768-980 short landscape.
+//   design mobile (<768) / tablet (<1024) / desktop: same buckets.
+// Gap 840-899 (unnamed by the manifest) is cut by orientation:
+// portrait stays tablet (overlay, chat/main), landscape joins
+// desktop-compact (single utility, split kept).
+
+import { classify, cohabit, exclusive, layouts, side, type Layout, type Viewport } from "@/tokens/viewport"
+
+export type { Layout, Viewport }
+export type Legacy = "mobile" | "tablet" | "desktop"
+
+export function legacy(width: number): Legacy {
+  if (!Number.isFinite(width) || width < 0) return "desktop"
+  if (width < 768) return "mobile"
+  if (width < 1024) return "tablet"
+  return "desktop"
+}
+
+type Summary = { id: Viewport; side: ReturnType<typeof side>; layouts: Layout[]; wide: boolean; single: boolean }
+
+export function describe(width: number, height: number): Summary {
+  const id = classify(width, height)
+  return { id, side: side(id), layouts: layouts(id), wide: cohabit(id), single: exclusive(id) }
+}


### PR DESCRIPTION
Stacked on #63 (A2-01) and the A2-02 PR. Part of Wave 0.5 (A2 Shell) — last A2 slice.

Scope (A2-03 only):
- packages/app/src/shell/v110-viewport.ts (+test): single responsive-authority classifier (desktop-wide/compact, tablet-portrait, phone-portrait, compact-landscape) resolving the RESPONSIVE-MATRIX.md contract — replaces the ad-hoc 768/1024/600/900/1200 breakpoints with one source of truth.
- packages/app/src/shell/v110-mobile-nav.tsx (+test): mobile navigation.
- packages/app/src/shell/v110-shell.css: responsive shell CSS.

Gate: bun typecheck green (47/47 packages). A8-01 Port Gate (#see companion PR) exercises this against the WAVE05 viewport matrix.