### PR TITLE
fix(app): pin ghostty-web to a fixed commit instead of a moving ref

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -68,7 +68,7 @@
     "diff": "catalog:",
     "effect": "catalog:",
     "fuzzysort": "catalog:",
-    "ghostty-web": "github:anomalyco/ghostty-web#main",
+    "ghostty-web": "github:anomalyco/ghostty-web#83c0a07",
     "luxon": "catalog:",
     "marked": "catalog:",
     "marked-shiki": "catalog:",


### PR DESCRIPTION
Unblocks CI (\`conformance\` / Install frozen-lockfile) currently red on PR #63, #64, #65, #66.

Root cause: \`packages/app/package.json\` pinned \`ghostty-web\` to \`github:anomalyco/ghostty-web#main\` (a moving branch ref). bun re-resolves it on every install; upstream main advanced past the commit frozen in bun.lock (83c0a07 -> 6e24d04), so every frozen-lockfile install now fails.

Reproduced on a clean checkout of \`work-design@d212bc80\` — pre-existing before the v110 port branch started, not introduced by A1/A2/A8.

Fix: pin to the commit already resolved in bun.lock (83c0a07). Zero dependency change. Verified: \`bun install --frozen-lockfile\` succeeds with no bun.lock diff, \`bun typecheck\` 47/47 green.

Should merge first, before the A2/A8 stack, so their CI can actually run.