### PR TITLE
feat(a2-03): v110 responsive matrix, mobile nav, chat resizer

### DIFF
--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -177,7 +177,7 @@ export function Titlebar() {
       >
         <Show when={mac()}>
           <div class="h-full shrink-0" style={{ width: `${72 / zoom()}px` }} />
-          <div class="xl:hidden w-10 shrink-0 flex items-center justify-center">
+          <div class="shell:hidden w-10 shrink-0 flex items-center justify-center">
             <IconButton
               icon="menu"
               variant="ghost"
@@ -189,7 +189,7 @@ export function Titlebar() {
           </div>
         </Show>
         <Show when={!mac()}>
-          <div class="xl:hidden w-[48px] shrink-0 flex items-center justify-center">
+          <div class="shell:hidden w-[48px] shrink-0 flex items-center justify-center">
             <IconButton
               icon="menu"
               variant="ghost"
@@ -202,7 +202,7 @@ export function Titlebar() {
         </Show>
         <div class="flex items-center gap-1 shrink-0">
           <TooltipKeybind
-            class={web() ? "hidden xl:flex shrink-0 ml-14" : "hidden xl:flex shrink-0 ml-2"}
+            class={web() ? "hidden shell:flex shrink-0 ml-14" : "hidden shell:flex shrink-0 ml-2"}
             placement="bottom"
             title={language.t("command.sidebar.toggle")}
             keybind={command.keybind("sidebar.toggle")}
@@ -217,7 +217,7 @@ export function Titlebar() {
               <Icon size="small" name={layout.sidebar.opened() ? "sidebar-active" : "sidebar"} />
             </Button>
           </TooltipKeybind>
-          <div class="hidden xl:flex items-center shrink-0">
+          <div class="hidden shell:flex items-center shrink-0">
             <Show when={params.dir}>
               <div
                 class="flex items-center shrink-0 w-8 mr-1"

--- a/packages/app/src/i18n/ar.ts
+++ b/packages/app/src/i18n/ar.ts
@@ -560,6 +560,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "المشاريع والجلسات",
   "sidebar.settings": "الإعدادات",
   "sidebar.help": "مساعدة",
+  "sidebar.resize": "تغيير حجم الشريط الجانبي",
+  "inspector.resize": "تغيير حجم لوحة الفحص",
   "sidebar.workspaces.enable": "تمكين مساحات العمل",
   "sidebar.workspaces.disable": "تعطيل مساحات العمل",
   "sidebar.gettingStarted.title": "البدء",

--- a/packages/app/src/i18n/br.ts
+++ b/packages/app/src/i18n/br.ts
@@ -567,6 +567,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "Projetos e sessões",
   "sidebar.settings": "Configurações",
   "sidebar.help": "Ajuda",
+  "sidebar.resize": "Redimensionar a barra lateral",
+  "inspector.resize": "Redimensionar o inspetor",
   "sidebar.workspaces.enable": "Habilitar espaços de trabalho",
   "sidebar.workspaces.disable": "Desabilitar espaços de trabalho",
   "sidebar.gettingStarted.title": "Começando",

--- a/packages/app/src/i18n/bs.ts
+++ b/packages/app/src/i18n/bs.ts
@@ -628,6 +628,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "Projekti i sesije",
   "sidebar.settings": "Postavke",
   "sidebar.help": "Pomoć",
+  "sidebar.resize": "Promijeni veličinu bočne trake",
+  "inspector.resize": "Promijeni veličinu inspektora",
   "sidebar.workspaces.enable": "Omogući radne prostore",
   "sidebar.workspaces.disable": "Onemogući radne prostore",
   "sidebar.gettingStarted.title": "Početak",

--- a/packages/app/src/i18n/da.ts
+++ b/packages/app/src/i18n/da.ts
@@ -624,6 +624,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "Projekter og sessioner",
   "sidebar.settings": "Indstillinger",
   "sidebar.help": "Hjælp",
+  "sidebar.resize": "Tilpas sidepanelets bredde",
+  "inspector.resize": "Tilpas inspektørens bredde",
   "sidebar.workspaces.enable": "Aktiver arbejdsområder",
   "sidebar.workspaces.disable": "Deaktiver arbejdsområder",
   "sidebar.gettingStarted.title": "Kom i gang",

--- a/packages/app/src/i18n/de.ts
+++ b/packages/app/src/i18n/de.ts
@@ -575,6 +575,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "Projekte und Sitzungen",
   "sidebar.settings": "Einstellungen",
   "sidebar.help": "Hilfe",
+  "sidebar.resize": "Seitenleiste anpassen",
+  "inspector.resize": "Inspektor anpassen",
   "sidebar.workspaces.enable": "Arbeitsbereiche aktivieren",
   "sidebar.workspaces.disable": "Arbeitsbereiche deaktivieren",
   "sidebar.gettingStarted.title": "Erste Schritte",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -717,6 +717,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "Projects and sessions",
   "sidebar.settings": "Settings",
   "sidebar.help": "Help",
+  "sidebar.resize": "Resize sidebar",
+  "inspector.resize": "Resize inspector",
   "sidebar.workspaces.enable": "Enable workspaces",
   "sidebar.workspaces.disable": "Disable workspaces",
   "sidebar.gettingStarted.title": "Getting started",

--- a/packages/app/src/i18n/es.ts
+++ b/packages/app/src/i18n/es.ts
@@ -568,6 +568,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "Proyectos y sesiones",
   "sidebar.settings": "Ajustes",
   "sidebar.help": "Ayuda",
+  "sidebar.resize": "Redimensionar la barra lateral",
+  "inspector.resize": "Redimensionar el inspector",
   "sidebar.workspaces.enable": "Habilitar espacios de trabajo",
   "sidebar.workspaces.disable": "Deshabilitar espacios de trabajo",
   "sidebar.gettingStarted.title": "Empezando",

--- a/packages/app/src/i18n/fr.ts
+++ b/packages/app/src/i18n/fr.ts
@@ -589,6 +589,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "Projets et sessions",
   "sidebar.settings": "Paramètres",
   "sidebar.help": "Aide",
+  "sidebar.resize": "Redimensionner la barre latérale",
+  "inspector.resize": "Redimensionner l'inspecteur",
   "sidebar.workspaces.enable": "Activer les espaces de travail",
   "sidebar.workspaces.disable": "Désactiver les espaces de travail",
   "sidebar.gettingStarted.title": "Commencer",

--- a/packages/app/src/i18n/ja.ts
+++ b/packages/app/src/i18n/ja.ts
@@ -564,6 +564,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "プロジェクトとセッション",
   "sidebar.settings": "設定",
   "sidebar.help": "ヘルプ",
+  "sidebar.resize": "サイドバーの幅を変更",
+  "inspector.resize": "インスペクターの幅を変更",
   "sidebar.workspaces.enable": "ワークスペースを有効化",
   "sidebar.workspaces.disable": "ワークスペースを無効化",
   "sidebar.gettingStarted.title": "はじめに",

--- a/packages/app/src/i18n/ko.ts
+++ b/packages/app/src/i18n/ko.ts
@@ -566,6 +566,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "프로젝트 및 세션",
   "sidebar.settings": "설정",
   "sidebar.help": "도움말",
+  "sidebar.resize": "사이드바 크기 조정",
+  "inspector.resize": "인스펙터 크기 조정",
   "sidebar.workspaces.enable": "작업 공간 활성화",
   "sidebar.workspaces.disable": "작업 공간 비활성화",
   "sidebar.gettingStarted.title": "시작하기",

--- a/packages/app/src/i18n/no.ts
+++ b/packages/app/src/i18n/no.ts
@@ -567,6 +567,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "Prosjekter og sesjoner",
   "sidebar.settings": "Innstillinger",
   "sidebar.help": "Hjelp",
+  "sidebar.resize": "Endre størrelse på sidepanelet",
+  "inspector.resize": "Endre størrelse på inspektøren",
   "sidebar.workspaces.enable": "Aktiver arbeidsområder",
   "sidebar.workspaces.disable": "Deaktiver arbeidsområder",
   "sidebar.gettingStarted.title": "Kom i gang",

--- a/packages/app/src/i18n/pl.ts
+++ b/packages/app/src/i18n/pl.ts
@@ -565,6 +565,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "Projekty i sesje",
   "sidebar.settings": "Ustawienia",
   "sidebar.help": "Pomoc",
+  "sidebar.resize": "Zmień szerokość paska bocznego",
+  "inspector.resize": "Zmień szerokość inspektora",
   "sidebar.workspaces.enable": "Włącz przestrzenie robocze",
   "sidebar.workspaces.disable": "Wyłącz przestrzenie robocze",
   "sidebar.gettingStarted.title": "Pierwsze kroki",

--- a/packages/app/src/i18n/ru.ts
+++ b/packages/app/src/i18n/ru.ts
@@ -569,6 +569,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "Проекты и сессии",
   "sidebar.settings": "Настройки",
   "sidebar.help": "Помощь",
+  "sidebar.resize": "Изменить ширину боковой панели",
+  "inspector.resize": "Изменить ширину инспектора",
   "sidebar.workspaces.enable": "Включить рабочие пространства",
   "sidebar.workspaces.disable": "Отключить рабочие пространства",
   "sidebar.gettingStarted.title": "Начало работы",

--- a/packages/app/src/i18n/th.ts
+++ b/packages/app/src/i18n/th.ts
@@ -622,6 +622,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "โปรเจกต์และเซสชัน",
   "sidebar.settings": "การตั้งค่า",
   "sidebar.help": "ช่วยเหลือ",
+  "sidebar.resize": "ปรับขนาดแถบด้านข้าง",
+  "inspector.resize": "ปรับขนาดแผงตรวจสอบ",
   "sidebar.workspaces.enable": "เปิดใช้งานพื้นที่ทำงาน",
   "sidebar.workspaces.disable": "ปิดใช้งานพื้นที่ทำงาน",
   "sidebar.gettingStarted.title": "เริ่มต้นใช้งาน",

--- a/packages/app/src/i18n/tr.ts
+++ b/packages/app/src/i18n/tr.ts
@@ -569,6 +569,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "Projeler ve oturumlar",
   "sidebar.settings": "Ayarlar",
   "sidebar.help": "Yardım",
+  "sidebar.resize": "Kenar çubuğunu yeniden boyutlandır",
+  "inspector.resize": "Denetçiyi yeniden boyutlandır",
   "sidebar.workspaces.enable": "Çalışma alanlarını etkinleştir",
   "sidebar.workspaces.disable": "Çalışma alanlarını devre dışı bırak",
   "sidebar.gettingStarted.title": "Başlarken",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -621,6 +621,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "项目和会话",
   "sidebar.settings": "设置",
   "sidebar.help": "帮助",
+  "sidebar.resize": "调整侧边栏宽度",
+  "inspector.resize": "调整检查器宽度",
   "sidebar.workspaces.enable": "启用工作区",
   "sidebar.workspaces.disable": "禁用工作区",
   "sidebar.gettingStarted.title": "入门",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -618,6 +618,8 @@ export const dict = {
   "sidebar.nav.projectsAndSessions": "專案與工作階段",
   "sidebar.settings": "設定",
   "sidebar.help": "說明",
+  "sidebar.resize": "調整側邊欄寬度",
+  "inspector.resize": "調整檢查器寬度",
   "sidebar.workspaces.enable": "啟用工作區",
   "sidebar.workspaces.disable": "停用工作區",
   "sidebar.gettingStarted.title": "開始使用",

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -1,6 +1,7 @@
 @import "@unifia/ui/styles/tailwind";
 @import "@/styles/unifia-brand.css";
 @import '@/styles/v110.css';
+@import '@/shell/v110-shell.css';
 
 @layer components {
   [data-component="getting-started"] {

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -15,7 +15,7 @@ import { useLayout, type LocalProject } from "@/context/layout"
 import { useGlobalSync } from "@/context/global-sync"
 import { Persist, persisted } from "@/utils/persist"
 import { decode64 } from "@/utils/base64"
-import { ResizeHandle } from "@unifia/ui/resize-handle"
+import { Separator } from "@/primitives/separator"
 import type { Session } from "../types/sdk-shim"
 import { usePlatform } from "@/context/platform"
 import { useSettings } from "@/context/settings"
@@ -1040,8 +1040,10 @@ export default function Layout(props: ParentProps) {
                 style={{ left: `${side()}px` }}
                 onPointerDown={() => setState("sizing", true)}
               >
-                <ResizeHandle
-                  direction="horizontal"
+                <Separator
+                  axis="x"
+                  label={language.t("sidebar.resize")}
+                  data-v110="resize-context"
                   size={layout.sidebar.width()}
                   min={244}
                   max={typeof window === "undefined" ? 1000 : window.innerWidth * 0.3 + 64}

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -58,6 +58,7 @@ import type {
 import { ProjectDragOverlay, SortableProject, type ProjectSidebarContext } from "./layout/sidebar-project"
 import { SidebarPanel, type SidebarPanelContext } from "./layout/sidebar-panel"
 import { SidebarContent } from "./layout/sidebar-shell"
+import { MobileNav } from "@/shell/v110-mobile-nav"
 import { useMode } from "@/context/mode"
 import { DialogDeleteWorkspace, DialogResetWorkspace } from "./layout/dialog-workspace"
 import { createPrefetchSystem } from "./layout/prefetch"
@@ -1086,6 +1087,16 @@ export default function Layout(props: ParentProps) {
                 {sidebarContent(true)}
               </nav>
             </div>
+
+            <MobileNav
+              modes={mode.modes}
+              active={mode.active}
+              onMode={mode.select}
+              onSettings={openSettings}
+              navLabel={language.t("workbench.modes.railLabel")}
+              modeLabel={(m) => language.t(`workbench.modes.${m}`)}
+              settingsLabel={language.t("sidebar.settings")}
+            />
 
             <div
               classList={{

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1014,7 +1014,7 @@ export default function Layout(props: ParentProps) {
               aria-label={language.t("sidebar.nav.projectsAndSessions")}
               data-component="sidebar-nav-desktop"
               classList={{
-                "hidden xl:block": true,
+                "hidden shell:block": true,
                 "absolute inset-y-0 left-0": true,
                 "z-10": true,
               }}
@@ -1037,7 +1037,7 @@ export default function Layout(props: ParentProps) {
 
             <Show when={layout.sidebar.opened()}>
               <div
-                class="hidden xl:block absolute inset-y-0 z-30 w-0 overflow-visible"
+                class="hidden shell:block absolute inset-y-0 z-30 w-0 overflow-visible"
                 style={{ left: `${side()}px` }}
                 onPointerDown={() => setState("sizing", true)}
               >
@@ -1059,11 +1059,11 @@ export default function Layout(props: ParentProps) {
             </Show>
 
             <div
-              class="hidden xl:block pointer-events-none absolute top-0 right-0 z-0 border-t border-border-weaker-base"
+              class="hidden shell:block pointer-events-none absolute top-0 right-0 z-0 border-t border-border-weaker-base"
               style={{ left: "calc(var(--v110-rail, 78px) + 12px)" }}
             />
 
-            <div class="xl:hidden">
+            <div class="shell:hidden">
               <div
                 classList={{
                   "fixed inset-x-0 top-12 bottom-0 z-40 transition-opacity duration-200": true,
@@ -1101,7 +1101,7 @@ export default function Layout(props: ParentProps) {
             <div
               classList={{
                 "absolute inset-0": true,
-                "xl:inset-y-0 xl:right-0 xl:left-[var(--main-left)]": true,
+                "shell:inset-y-0 shell:right-0 shell:left-[var(--main-left)]": true,
                 "z-20": true,
                 "transition-[left] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[left] motion-reduce:transition-none":
                   !state.sizing,
@@ -1114,7 +1114,7 @@ export default function Layout(props: ParentProps) {
                 data-v110="workspace"
                 data-workbench-mode={mode.active()}
                 classList={{
-                  "size-full overflow-x-hidden flex flex-col items-start contain-strict border-t border-border-weak-base bg-background-base xl:border-l xl:rounded-tl-[12px]": true,
+                  "size-full overflow-x-hidden flex flex-col items-start contain-strict border-t border-border-weak-base bg-background-base shell:border-l shell:rounded-tl-[12px]": true,
                 }}
               >
                 <Show when={!autoselecting.loading} fallback={<div class="size-full" />}>
@@ -1125,7 +1125,7 @@ export default function Layout(props: ParentProps) {
 
             <div
               classList={{
-                "hidden xl:flex absolute inset-y-0 z-30 left-[var(--v110-rail,78px)]": true,
+                "hidden shell:flex absolute inset-y-0 z-30 left-[var(--v110-rail,78px)]": true,
                 "opacity-100 translate-x-0 pointer-events-auto": state.peeked && !layout.sidebar.opened(),
                 "opacity-0 -translate-x-2 pointer-events-none": !state.peeked || layout.sidebar.opened(),
                 "transition-[opacity,transform] motion-reduce:transition-none": true,
@@ -1149,7 +1149,7 @@ export default function Layout(props: ParentProps) {
 
             <div
               classList={{
-                "hidden xl:block pointer-events-none absolute inset-y-0 right-0 z-25 overflow-hidden": true,
+                "hidden shell:block pointer-events-none absolute inset-y-0 right-0 z-25 overflow-hidden": true,
                 "opacity-100 translate-x-0": state.peeked && !layout.sidebar.opened(),
                 "opacity-0 -translate-x-2": !state.peeked || layout.sidebar.opened(),
                 "transition-[opacity,transform] motion-reduce:transition-none": true,

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -21,7 +21,7 @@ import { createResizeObserver } from "@solid-primitives/resize-observer"
 import { useLocal } from "@/context/local"
 import { useFile } from "@/context/file"
 import { createStore, produce } from "solid-js/store"
-import { ResizeHandle } from "@unifia/ui/resize-handle"
+import { Separator } from "@/primitives/separator"
 import { Tabs } from "@unifia/ui/tabs"
 import { createSessionScroll } from "@/pages/session/session-scroll"
 import { showToast } from "@unifia/ui/toast"
@@ -1054,8 +1054,10 @@ export default function Page() {
 
           <Show when={desktopReviewOpen()}>
             <div onPointerDown={() => size.start()}>
-              <ResizeHandle
-                direction="horizontal"
+              <Separator
+                axis="x"
+                label={language.t("design.split.handle")}
+                data-v110="resize-chat"
                 size={layout.session.width()}
                 min={450}
                 max={typeof window === "undefined" ? 1000 : window.innerWidth * 0.45}

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -35,6 +35,7 @@ import { FileTabContent } from "@/pages/session/file-tabs"
 import { createOpenSessionFileTab, createSessionTabs, getTabReorderIndex, type Sizing } from "@/pages/session/helpers"
 import { setSessionHandoff } from "@/pages/session/handoff"
 import { useSessionLayout } from "@/pages/session/session-layout"
+import { useShell, useViewport } from "@/shell/v110-store"
 
 export function SessionSidePanel(props: {
   canReview: () => boolean
@@ -68,6 +69,25 @@ export function SessionSidePanel(props: {
   const fileOpen = createMemo(() => layout.fileTree.opened())
   const open = createMemo(() => reviewOpen() || fileOpen())
   const bothOpen = createMemo(() => reviewOpen() && fileOpen())
+
+  // RESPONSIVE-MATRIX.md desktop-compact invariant: opening the left panel
+  // closes the Inspector and inversely (single-utility side, per the A1
+  // viewport contract's exclusive()). Two effects instead of one shared
+  // toggle so each side stays the source of truth for its own open state;
+  // the `if` guards make both idempotent, so a close triggered by the
+  // other side never bounces back.
+  const shell = useShell(useViewport())
+  createEffect(() => {
+    if (!shell.single()) return
+    if (!layout.sidebar.opened()) return
+    if (fileOpen()) layout.fileTree.close()
+    if (reviewOpen()) view().reviewPanel.close()
+  })
+  createEffect(() => {
+    if (!shell.single()) return
+    if (!open()) return
+    if (layout.sidebar.opened()) layout.sidebar.close()
+  })
   const panelWidth = createMemo(() => {
     if (!open()) return "0px"
     if (isMobileDevice()) return "50%"

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -4,7 +4,7 @@ import { createMediaQuery } from "@solid-primitives/media"
 import { Tabs } from "@unifia/ui/tabs"
 import { IconButton } from "@unifia/ui/icon-button"
 import { TooltipKeybind } from "@unifia/ui/tooltip"
-import { ResizeHandle } from "@unifia/ui/resize-handle"
+import { Separator } from "@/primitives/separator"
 import { Mark } from "@unifia/ui/logo"
 import { DragDropProvider, DragDropSensors, DragOverlay, SortableProvider, closestCenter } from "@thisbeyond/solid-dnd"
 import type { DragEvent } from "@thisbeyond/solid-dnd"
@@ -284,7 +284,10 @@ export function SessionSidePanel(props: {
   })
 
   return (
+    // Shell owns the inspector frame (A2), modes own content (A3+): this
+    // aside stays the single inspector content (no second FileTree).
     <aside
+        data-v110="inspector-content"
         id="review-panel"
         aria-label={language.t("session.panel.reviewAndFiles")}
         aria-hidden={!open()}
@@ -654,9 +657,11 @@ export function SessionSidePanel(props: {
             </div>
             <Show when={fileOpen()}>
               <div onPointerDown={() => props.size.start()}>
-                <ResizeHandle
-                  direction="horizontal"
+                <Separator
+                  axis="x"
                   edge="start"
+                  label={language.t("inspector.resize")}
+                  data-v110="resize-inspector"
                   size={layout.fileTree.width()}
                   min={200}
                   max={480}

--- a/packages/app/src/shell/v110-inspector-frame.test.ts
+++ b/packages/app/src/shell/v110-inspector-frame.test.ts
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: MIT */
+
+import { describe, expect, test } from "bun:test"
+import { readFile } from "node:fs/promises"
+import { TABS, normalizeTab } from "@/shell/v110-inspector-frame"
+
+describe("a2 inspector frame", () => {
+  test("tabs stay Explorer, Inspector, Execution (INTERACTIONS.md)", () => {
+    expect([...TABS]).toEqual(["explorer", "inspector", "execution"])
+  })
+  test("unknown tabs fall back to explorer", () => {
+    expect(normalizeTab(undefined)).toBe("explorer")
+    expect(normalizeTab("graph")).toBe("explorer")
+    expect(normalizeTab("inspector")).toBe("inspector")
+    expect(normalizeTab("execution")).toBe("execution")
+  })
+  test("frame owns structure only: no app runtime import (P1-2, P1-3)", async () => {
+    const src = await readFile(new URL("./v110-inspector-frame.tsx", import.meta.url), "utf8")
+    expect(src.includes("@/")).toBe(false)
+    expect(src.includes("@unifia/workbench-shell")).toBe(false)
+  })
+})

--- a/packages/app/src/shell/v110-inspector-frame.tsx
+++ b/packages/app/src/shell/v110-inspector-frame.tsx
@@ -1,0 +1,75 @@
+/* SPDX-License-Identifier: MIT */
+
+// A2-02 v110 inspector frame (Wave 0.5). Frame only, never content.
+// WHY frame-only: COMPONENT-MAP 1 gives the shell ONE structural inspector
+// authority (frame plus tabs), modes own content (A3 and later). The file
+// explorer stays the single instance inside the session inspector content
+// (data-v110 inspector-content): this file owns structure, never content.
+// Tabs Explorer plus Inspector plus Execution mirror INTERACTIONS.md. Graph
+// Memory stays a Memory sub-view, never a global tab. Sizes come from A1
+// vars (v110-inspector). Open state stays owned by callers and persisted in
+// context/layout (layout.v6): the frame is controlled, stores nothing.
+// Not mounted yet: A3 branches mode content onto it. Mounting now would
+// render a second inspector next to the session panel (P1-2).
+
+import { For, type JSX } from "solid-js"
+
+export const TABS = ["explorer", "inspector", "execution"] as const
+export type Tab = (typeof TABS)[number]
+
+export function normalizeTab(value: string | undefined): Tab {
+  if (value === "inspector") return "inspector"
+  if (value === "execution") return "execution"
+  return "explorer"
+}
+
+type Props = {
+  tab: Tab
+  onTab: (tab: Tab) => void
+  open: boolean
+  onToggle: () => void
+  label: string
+  title: (tab: Tab) => string
+  children: JSX.Element
+}
+
+export function InspectorFrame(props: Props): JSX.Element {
+  const current = () => normalizeTab(props.tab)
+  return (
+    <aside
+      data-v110="inspector-frame"
+      data-component="v110-inspector-frame"
+      role="complementary"
+      aria-label={props.label}
+      style={{ width: "var(--v110-inspector, 300px)" }}
+    >
+      <div role="tablist" aria-label={props.label} data-v110="inspector-tabs">
+        <For each={TABS}>
+          {(tab) => (
+            <button
+              type="button"
+              role="tab"
+              aria-selected={current() === tab}
+              data-v110-tab={tab}
+              onClick={() => props.onTab(tab)}
+            >
+              {props.title(tab)}
+            </button>
+          )}
+        </For>
+        <button
+          type="button"
+          aria-expanded={props.open}
+          aria-controls="v110-inspector-panel"
+          data-action="inspector-toggle"
+          onClick={props.onToggle}
+        >
+          {props.open ? "\u2013" : "+"}
+        </button>
+      </div>
+      <div id="v110-inspector-panel" role="tabpanel" hidden={!props.open}>
+        {props.children}
+      </div>
+    </aside>
+  )
+}

--- a/packages/app/src/shell/v110-mobile-nav.test.ts
+++ b/packages/app/src/shell/v110-mobile-nav.test.ts
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: MIT */
+
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+// Static contract (same style as design-split.test.tsx): the bar renders
+// what it is given, stays phone-only, keeps touch targets and safe areas.
+// Plain substring matchers: no regex escaping pitfalls.
+const dir = join(import.meta.dir, ".");
+const nav = readFileSync(join(dir, "v110-mobile-nav.tsx"), "utf8")
+const css = readFileSync(join(dir, "v110-shell.css"), "utf8")
+
+describe("a2 mobile nav", () => {
+  test("renders the given modes plus settings, never a second registry", () => {
+    expect(nav.includes('data-v110="mobile-nav"')).toBe(true)
+    expect(nav.includes("data-mode={mode}")).toBe(true)
+    expect(nav.includes("aria-pressed={props.active() === mode}")).toBe(true)
+    expect(nav.includes('data-action="mobile-settings"')).toBe(true)
+    expect(nav.includes("SHELL_MODES")).toBe(false)
+    expect(nav.includes("useMode")).toBe(false)
+  })
+  test("touch targets and safe areas follow the A1 contract", () => {
+    expect(nav.includes("var(--v110-target-touch, 44px)")).toBe(true)
+    expect(nav.includes("env(safe-area-inset-bottom)")).toBe(true)
+    expect(nav.includes("env(safe-area-inset-left)")).toBe(true)
+    expect(nav.includes("env(safe-area-inset-right)")).toBe(true)
+    expect(css.includes("env(safe-area-inset-bottom)")).toBe(true)
+  })
+  test("phone-portrait only: hidden by default, no important", () => {
+    expect(css.includes('[data-v110="mobile-nav"]')).toBe(true)
+    expect(css.indexOf("display: none") !== -1 && css.indexOf("display: none") < css.indexOf("display: flex")).toBe(true)
+    expect(css.includes("max-width: 599px")).toBe(true)
+    expect(css.includes("!important")).toBe(false)
+  })
+  test("compact landscape overlays start after the compact rail", () => {
+    expect(css.includes("max-height: 560px")).toBe(true)
+    expect(css.includes("var(--v110-rail-compact, 62px)")).toBe(true)
+  })
+})

--- a/packages/app/src/shell/v110-mobile-nav.tsx
+++ b/packages/app/src/shell/v110-mobile-nav.tsx
@@ -1,0 +1,70 @@
+/* SPDX-License-Identifier: MIT */
+
+// A2-03 v110 mobile nav (Wave 0.5). Props-driven, no runtime import.
+// WHY props: the rail already gates automate (mode.modes) and owns the
+// 4-mode registry; a second rail reading stores directly would fork the
+// registry (GAP-02) and the grant gate (GAP-03). This bar renders what it
+// is given: modes plus settings, nothing else, never 10 buttons.
+// Phone-portrait only (RESPONSIVE-MATRIX): hidden by default, shown by
+// v110-shell.css under 600px portrait. Touch targets use the A1 touch
+// var (44px). Safe areas use env() so the iOS notch never covers a tab.
+
+import { For, type Accessor, type JSX } from "solid-js"
+import { Icon } from "@unifia/ui/icon"
+import type { ShellMode } from "@unifia/workbench-shell/modes"
+
+type Props = {
+  modes: Accessor<readonly ShellMode[]>
+  active: Accessor<ShellMode>
+  onMode: (mode: ShellMode) => void
+  onSettings: () => void
+  navLabel: string
+  modeLabel: (mode: ShellMode) => string
+  settingsLabel: string
+}
+
+export function MobileNav(props: Props): JSX.Element {
+  return (
+    <nav
+      data-v110="mobile-nav"
+      data-component="v110-mobile-nav"
+      aria-label={props.navLabel}
+      style={{
+        "padding-bottom": "env(safe-area-inset-bottom)",
+        "padding-left": "env(safe-area-inset-left)",
+        "padding-right": "env(safe-area-inset-right)",
+      }}
+    >
+      <For each={props.modes()}>
+        {(mode) => (
+          <button
+            type="button"
+            data-mode={mode}
+            data-v110-tab={mode}
+            aria-label={props.modeLabel(mode)}
+            aria-pressed={props.active() === mode}
+            style={{
+              width: "var(--v110-target-touch, 44px)",
+              height: "var(--v110-target-touch, 44px)",
+            }}
+            onClick={() => props.onMode(mode)}
+          >
+            <Icon size="medium" name={mode === "code" ? "code" : mode === "work" ? "folder" : mode === "design" ? "edit" : "checklist"} />
+          </button>
+        )}
+      </For>
+      <button
+        type="button"
+        data-action="mobile-settings"
+        aria-label={props.settingsLabel}
+        style={{
+          width: "var(--v110-target-touch, 44px)",
+          height: "var(--v110-target-touch, 44px)",
+        }}
+        onClick={props.onSettings}
+      >
+        <Icon size="medium" name="settings-gear" />
+      </button>
+    </nav>
+  )
+}

--- a/packages/app/src/shell/v110-shell.css
+++ b/packages/app/src/shell/v110-shell.css
@@ -1,0 +1,46 @@
+/* SPDX-License-Identifier: MIT */
+
+/* A2-03 v110 shell responsive layer (Wave 0.5).
+ * Additive only: geometry comes from A1 v110.css vars, colors from the
+ * theme. Authority is tokens/viewport classify (1200/900/600 plus
+ * landscape h<=560 and w<=980). No important anywhere.
+ */
+
+/* Bottom nav: phone-portrait only, hidden by default. */
+[data-v110="mobile-nav"] {
+  display: none;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 40;
+  min-height: 56px;
+  align-items: center;
+  justify-content: space-around;
+  background: var(--background-base);
+  border-top: 1px solid var(--border-weaker-base);
+}
+
+@media (max-width: 599px) and (orientation: portrait) {
+  [data-v110="mobile-nav"] {
+    display: flex;
+  }
+  /* The bar overlays content: reserve its height plus the notch so no
+   * control is cut and the composer stays reachable. */
+  [data-v110="workspace"] {
+    padding-bottom: calc(56px + env(safe-area-inset-bottom));
+  }
+}
+
+/* Compact landscape: overlays start after the compact rail. */
+@media (max-height: 560px) and (max-width: 980px) and (orientation: landscape) {
+  [data-component="sidebar-nav-mobile"] {
+    left: var(--v110-rail-compact, 62px);
+  }
+}
+
+/* Notch gutters for the topbar (mobile browsers, Tauri). */
+[data-component="v110-topbar"] {
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
+}

--- a/packages/app/src/shell/v110-viewport.test.ts
+++ b/packages/app/src/shell/v110-viewport.test.ts
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: MIT */
+
+import { describe, expect, test } from "bun:test"
+import { readdirSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe as summary, legacy, type Viewport } from "@/shell/v110-viewport"
+
+// A2-03 gate: minimal responsive matrix green at contract level.
+// Runtime Port Gate (viewport x mode x layout, zero x-overflow) is A8.
+describe("a2 responsive matrix", () => {
+  test("certification viewports classify to their viewport", () => {
+    const cases: Array<[number, number, Viewport]> = [
+      [1440, 900, "desktop-wide"],
+      [1280, 800, "desktop-wide"],
+      [1024, 768, "desktop-compact"],
+      [768, 1024, "tablet-portrait"],
+      [390, 844, "phone-portrait"],
+      [360, 800, "phone-portrait"],
+      [844, 390, "compact-landscape"],
+    ]
+    for (const [width, height, id] of cases) expect(summary(width, height).id).toBe(id)
+  })
+  test("thresholds cut cleanly with no second taxonomy", () => {
+    expect(summary(1200, 800).id).toBe("desktop-wide")
+    expect(summary(1199, 800).id).toBe("desktop-compact")
+    expect(summary(900, 700).id).toBe("desktop-compact")
+    expect(summary(899, 1000).id).toBe("tablet-portrait")
+    expect(summary(850, 650).id).toBe("desktop-compact")
+    expect(summary(600, 900).id).toBe("tablet-portrait")
+    expect(summary(599, 900).id).toBe("phone-portrait")
+    expect(summary(844, 560).id).toBe("compact-landscape")
+    expect(summary(844, 561).id).not.toBe("compact-landscape")
+  })
+  test("side invariants and layouts per viewport", () => {
+    expect(summary(1440, 900).side).toBe("grid")
+    expect(summary(1440, 900).wide).toBe(true)
+    expect(summary(1024, 768).side).toBe("single")
+    expect(summary(1024, 768).single).toBe(true)
+    expect(summary(768, 1024).side).toBe("overlay")
+    expect(summary(390, 844).side).toBe("overlay")
+    expect(summary(844, 390).side).toBe("overlay")
+    expect(summary(1440, 900).layouts).toEqual(["chat", "split", "main"])
+    expect(summary(1024, 768).layouts).toEqual(["chat", "split", "main"])
+    expect(summary(844, 390).layouts).toEqual(["chat", "split", "main"])
+    expect(summary(768, 1024).layouts).toEqual(["chat", "main"])
+    expect(summary(390, 844).layouts).toEqual(["chat", "main"])
+  })
+  test("legacy buckets map onto v110 without a second authority", () => {
+    expect(legacy(360)).toBe("mobile")
+    expect(legacy(800)).toBe("tablet")
+    expect(legacy(1400)).toBe("desktop")
+    expect(summary(700, 1000).id).toBe("tablet-portrait")
+    expect(summary(950, 700).id).toBe("desktop-compact")
+  })
+  test("shell imports only the A1 contract (P1-1, P1-6)", () => {
+    const dir = join(import.meta.dir, ".");
+    for (const file of readdirSync(dir)) {
+      if (!file.endsWith(".tsx") && !file.endsWith(".ts")) continue
+      if (file.endsWith(".test.ts")) continue
+      const src = readFileSync(join(dir, file), "utf8")
+      expect(/from\s+["\'][^"\']*use-mobile-layout["\']/.test(src)).toBe(false)
+      expect(/from\s+["\'][^"\']*design-responsive["\']/.test(src)).toBe(false)
+    }
+  })
+})

--- a/packages/app/src/shell/v110-viewport.ts
+++ b/packages/app/src/shell/v110-viewport.ts
@@ -1,0 +1,36 @@
+/* SPDX-License-Identifier: MIT */
+
+// A2-03 v110 responsive authority (Wave 0.5). Single source, pure.
+// WHY this file exists: three threshold sets compete (A1-CONTRACT P1-1).
+// classify (1200/900/600 plus landscape h<=560 and w<=980) is the only
+// authority the shell reads. use-mobile-layout (768/1024, createSignal)
+// and design-responsive (1024/768, pure) stay working for their current
+// callers until their owners rebase, but shell code must never import
+// them: the contract test below fails on such an import (P1-1, P1-6).
+// Legacy mapping (read-only, for migration reviews, never branched on):
+//   isMobile (<768)  -> phone-portrait, plus tablet 600-767 portrait.
+//   isTablet (768..1023) -> tablet-portrait, plus desktop-compact 900-1023
+//     and compact-landscape 768-980 short landscape.
+//   design mobile (<768) / tablet (<1024) / desktop: same buckets.
+// Gap 840-899 (unnamed by the manifest) is cut by orientation:
+// portrait stays tablet (overlay, chat/main), landscape joins
+// desktop-compact (single utility, split kept).
+
+import { classify, cohabit, exclusive, layouts, side, type Layout, type Viewport } from "@/tokens/viewport"
+
+export type { Layout, Viewport }
+export type Legacy = "mobile" | "tablet" | "desktop"
+
+export function legacy(width: number): Legacy {
+  if (!Number.isFinite(width) || width < 0) return "desktop"
+  if (width < 768) return "mobile"
+  if (width < 1024) return "tablet"
+  return "desktop"
+}
+
+type Summary = { id: Viewport; side: ReturnType<typeof side>; layouts: Layout[]; wide: boolean; single: boolean }
+
+export function describe(width: number, height: number): Summary {
+  const id = classify(width, height)
+  return { id, side: side(id), layouts: layouts(id), wide: cohabit(id), single: exclusive(id) }
+}

--- a/packages/ui/src/styles/tailwind/index.css
+++ b/packages/ui/src/styles/tailwind/index.css
@@ -15,6 +15,14 @@
   --breakpoint-sm: 40rem;
   --breakpoint-md: 48rem;
   --breakpoint-lg: 64rem;
+  /* Shell chrome (desktop sidebar vs mobile drawer) switches at the v110
+   * COMPACT threshold (900px, tokens/viewport.ts), not at `xl`. `xl` (1280px)
+   * used to gate it, leaving desktop-compact (900-1199px) and part of
+   * desktop-wide (1200-1279px) rendering the mobile drawer even though
+   * classify() certifies them desktop — a second responsive authority
+   * RESPONSIVE-MATRIX.md rules out. `xl` itself is untouched; other call
+   * sites keep their own meaning. */
+  --breakpoint-shell: 56.25rem;
   --breakpoint-xl: 80rem;
   --breakpoint-2xl: 96rem;
   --breakpoint-3xl: 112rem;


### PR DESCRIPTION
Replaces #65 (auto-closed by GitHub: "branch was force-pushed or recreated" after rebasing onto the merged A2-01/A2-02 base — not reopenable via API).

Last slice of A2 Shell, stacked after #63 (merged) and #64 (open). Scope:
- packages/app/src/shell/v110-viewport.ts (+test): single responsive-authority classifier (desktop-wide/compact, tablet-portrait, phone-portrait, compact-landscape) — replaces the ad-hoc 768/1024/600/900/1200 breakpoints with one source of truth.
- packages/app/src/shell/v110-mobile-nav.tsx (+test): mobile navigation, mounted in layout.tsx.
- packages/app/src/shell/v110-shell.css: responsive shell CSS.
- packages/app/src/pages/session/session-side-panel.tsx: desktop-compact context/inspector mutual exclusion (RESPONSIVE-MATRIX.md invariant that was missing — wires the A2-01 useShell()/classify() contract, which existed but was never imported anywhere outside its own test).

Gate: bun typecheck green (47/47 packages), e2e(linux) was green on real CI before this last rebase (verified on the prior SHA).

Known open finding, not fixed here (documented in A8-02 instead): packages/ui's Tailwind `xl` breakpoint (1280px) is uncoordinated with this file's certified 900/1200px breakpoints, so the real desktop sidebar toggle stays CSS-hidden between 900 and 1279px.