### PR TITLE
feat(a3-01): message hover actions + prompt graduation ticks

### DIFF
--- a/packages/app/src/i18n/ar.ts
+++ b/packages/app/src/i18n/ar.ts
@@ -489,6 +489,7 @@ export const dict = {
   "session.messages.loadEarlier": "تحميل الرسائل السابقة",
   "session.messages.loading": "جارٍ تحميل الرسائل...",
   "session.messages.jumpToLatest": "الانتقال إلى الأحدث",
+  "session.promptIndex.label": "التنقل بين المطالبات",
   "session.context.addToContext": "إضافة {{selection}} إلى السياق",
   "session.todo.title": "المهام",
   "session.todo.collapse": "طي",

--- a/packages/app/src/i18n/br.ts
+++ b/packages/app/src/i18n/br.ts
@@ -493,6 +493,7 @@ export const dict = {
   "session.messages.loadEarlier": "Carregar mensagens anteriores",
   "session.messages.loading": "Carregando mensagens...",
   "session.messages.jumpToLatest": "Ir para a mais recente",
+  "session.promptIndex.label": "Navegar entre os prompts",
   "session.context.addToContext": "Adicionar {{selection}} ao contexto",
   "session.todo.title": "Tarefas",
   "session.todo.collapse": "Recolher",

--- a/packages/app/src/i18n/bs.ts
+++ b/packages/app/src/i18n/bs.ts
@@ -547,6 +547,7 @@ export const dict = {
   "session.messages.loadEarlier": "Učitaj ranije poruke",
   "session.messages.loading": "Učitavanje poruka...",
   "session.messages.jumpToLatest": "Idi na najnovije",
+  "session.promptIndex.label": "Kretanje između upita",
 
   "session.context.addToContext": "Dodaj {{selection}} u kontekst",
   "session.todo.title": "Zadaci",

--- a/packages/app/src/i18n/da.ts
+++ b/packages/app/src/i18n/da.ts
@@ -543,6 +543,7 @@ export const dict = {
   "session.messages.loading": "Indlæser beskeder...",
 
   "session.messages.jumpToLatest": "Gå til seneste",
+  "session.promptIndex.label": "Naviger mellem prompts",
   "session.context.addToContext": "Tilføj {{selection}} til kontekst",
   "session.todo.title": "Opgaver",
   "session.todo.collapse": "Skjul",

--- a/packages/app/src/i18n/de.ts
+++ b/packages/app/src/i18n/de.ts
@@ -501,6 +501,7 @@ export const dict = {
   "session.messages.loadEarlier": "Frühere Nachrichten laden",
   "session.messages.loading": "Lade Nachrichten...",
   "session.messages.jumpToLatest": "Zum neuesten springen",
+  "session.promptIndex.label": "Zwischen Prompts wechseln",
   "session.context.addToContext": "{{selection}} zum Kontext hinzufügen",
   "session.todo.title": "Aufgaben",
   "session.todo.collapse": "Einklappen",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -600,6 +600,7 @@ export const dict = {
   "session.messages.loadEarlier": "Load earlier messages",
   "session.messages.loading": "Loading messages...",
   "session.messages.jumpToLatest": "Jump to latest",
+  "session.promptIndex.label": "Jump between prompts",
   "session.context.addToContext": "Add {{selection}} to context",
   "session.todo.title": "Todos",
   "session.todo.collapse": "Collapse",

--- a/packages/app/src/i18n/es.ts
+++ b/packages/app/src/i18n/es.ts
@@ -494,6 +494,7 @@ export const dict = {
   "session.messages.loadEarlier": "Cargar mensajes anteriores",
   "session.messages.loading": "Cargando mensajes...",
   "session.messages.jumpToLatest": "Ir al último",
+  "session.promptIndex.label": "Navegar entre los prompts",
   "session.context.addToContext": "Añadir {{selection}} al contexto",
   "session.todo.title": "Tareas",
   "session.todo.collapse": "Contraer",

--- a/packages/app/src/i18n/fr.ts
+++ b/packages/app/src/i18n/fr.ts
@@ -511,6 +511,7 @@ export const dict = {
   "session.messages.loadEarlier": "Charger les messages précédents",
   "session.messages.loading": "Chargement des messages...",
   "session.messages.jumpToLatest": "Aller au dernier",
+  "session.promptIndex.label": "Naviguer entre les prompts",
   "session.context.addToContext": "Ajouter {{selection}} au contexte",
   "session.todo.title": "Tâches",
   "session.todo.collapse": "Réduire",

--- a/packages/app/src/i18n/ja.ts
+++ b/packages/app/src/i18n/ja.ts
@@ -490,6 +490,7 @@ export const dict = {
   "session.messages.loadEarlier": "以前のメッセージを読み込む",
   "session.messages.loading": "メッセージを読み込み中...",
   "session.messages.jumpToLatest": "最新へジャンプ",
+  "session.promptIndex.label": "プロンプト間を移動",
   "session.context.addToContext": "{{selection}}をコンテキストに追加",
   "session.todo.title": "ToDo",
   "session.todo.collapse": "折りたたむ",

--- a/packages/app/src/i18n/ko.ts
+++ b/packages/app/src/i18n/ko.ts
@@ -493,6 +493,7 @@ export const dict = {
   "session.messages.loadEarlier": "이전 메시지 로드",
   "session.messages.loading": "메시지 로드 중...",
   "session.messages.jumpToLatest": "최신으로 이동",
+  "session.promptIndex.label": "프롬프트 간 이동",
   "session.context.addToContext": "컨텍스트에 {{selection}} 추가",
   "session.todo.title": "할 일",
   "session.todo.collapse": "접기",

--- a/packages/app/src/i18n/no.ts
+++ b/packages/app/src/i18n/no.ts
@@ -493,6 +493,7 @@ export const dict = {
   "session.messages.loadEarlier": "Last inn tidligere meldinger",
   "session.messages.loading": "Laster meldinger...",
   "session.messages.jumpToLatest": "Hopp til nyeste",
+  "session.promptIndex.label": "Naviger mellom prompter",
   "session.context.addToContext": "Legg til {{selection}} i kontekst",
   "session.todo.title": "Oppgaver",
   "session.todo.collapse": "Skjul",

--- a/packages/app/src/i18n/pl.ts
+++ b/packages/app/src/i18n/pl.ts
@@ -491,6 +491,7 @@ export const dict = {
   "session.messages.loadEarlier": "Załaduj wcześniejsze wiadomości",
   "session.messages.loading": "Ładowanie wiadomości...",
   "session.messages.jumpToLatest": "Przejdź do najnowszych",
+  "session.promptIndex.label": "Nawiguj między promptami",
   "session.context.addToContext": "Dodaj {{selection}} do kontekstu",
   "session.todo.title": "Zadania",
   "session.todo.collapse": "Zwiń",

--- a/packages/app/src/i18n/ru.ts
+++ b/packages/app/src/i18n/ru.ts
@@ -495,6 +495,7 @@ export const dict = {
   "session.messages.loadEarlier": "Загрузить предыдущие сообщения",
   "session.messages.loading": "Загрузка сообщений...",
   "session.messages.jumpToLatest": "Перейти к последнему",
+  "session.promptIndex.label": "Переход между запросами",
   "session.context.addToContext": "Добавить {{selection}} в контекст",
   "session.todo.title": "Задачи",
   "session.todo.collapse": "Свернуть",

--- a/packages/app/src/i18n/th.ts
+++ b/packages/app/src/i18n/th.ts
@@ -542,6 +542,7 @@ export const dict = {
   "session.messages.loadEarlier": "โหลดข้อความก่อนหน้า",
   "session.messages.loading": "กำลังโหลดข้อความ...",
   "session.messages.jumpToLatest": "ไปที่ล่าสุด",
+  "session.promptIndex.label": "นำทางระหว่างพรอมป์ต่าง ๆ",
 
   "session.context.addToContext": "เพิ่ม {{selection}} ไปยังบริบท",
   "session.todo.title": "สิ่งที่ต้องทำ",

--- a/packages/app/src/i18n/tr.ts
+++ b/packages/app/src/i18n/tr.ts
@@ -496,6 +496,7 @@ export const dict = {
   "session.messages.loadEarlier": "Önceki mesajları yükle",
   "session.messages.loading": "Mesajlar yükleniyor...",
   "session.messages.jumpToLatest": "En sona atla",
+  "session.promptIndex.label": "İstemler arasında gezin",
   "session.context.addToContext": "{{selection}} bağlama ekle",
   "session.todo.title": "Görevler",
   "session.todo.collapse": "Daralt",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -543,6 +543,7 @@ export const dict = {
   "session.messages.loadEarlier": "加载更早的消息",
   "session.messages.loading": "正在加载消息...",
   "session.messages.jumpToLatest": "跳转到最新",
+  "session.promptIndex.label": "在提示之间导航",
   "session.context.addToContext": "将 {{selection}} 添加到上下文",
   "session.todo.title": "待办事项",
   "session.todo.collapse": "折叠",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -539,6 +539,7 @@ export const dict = {
   "session.messages.loading": "正在載入訊息...",
 
   "session.messages.jumpToLatest": "跳到最新",
+  "session.promptIndex.label": "在提示之間導覽",
   "session.context.addToContext": "將 {{selection}} 新增到上下文",
   "session.todo.title": "待辦事項",
   "session.todo.collapse": "折疊",

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -2,6 +2,7 @@
 @import "@/styles/unifia-brand.css";
 @import '@/styles/v110.css';
 @import '@/shell/v110-shell.css';
+@import '@/pages/session/v110-chat.css';
 
 @layer components {
   [data-component="getting-started"] {

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -41,6 +41,7 @@ import { useWorkspaceWorkbench } from "@/context/workbench/provider"
 import { createSessionComposerState, SessionComposerRegion } from "@/pages/session/composer"
 import { createOpenReviewFile, createSessionTabs, createSizing } from "@/pages/session/helpers"
 import { MessageTimeline } from "@/pages/session/message-timeline"
+import { PromptIndex } from "@/pages/session/prompt-index"
 import { useSessionLayout } from "@/pages/session/session-layout"
 import { syncSessionModel } from "@/pages/session/session-model-helpers"
 import { SessionSidePanel } from "@/pages/session/session-side-panel"
@@ -84,6 +85,11 @@ export default function Page() {
   const navigate = useNavigate()
   const workbench = useWorkspaceWorkbench()
   const [artifactDocument, setArtifactDocument] = createSignal<{ filename: string; content: string }>()
+  // Read-only capture of the message-timeline scroll viewport for
+  // PromptIndex (A3-01). Wraps setScrollRef below rather than reaching
+  // into createSessionScroll/createAutoScroll internals: this signal
+  // has no write path back into the existing scroll machinery.
+  const [scrollEl, setScrollEl] = createSignal<HTMLDivElement>()
   const [artifactError, setArtifactError] = createSignal<string>()
   const { params, sessionKey, tabs, view } = useSessionLayout()
   // FORK: ADR-0005 dual-mode layout effect (Agent ⇄ IDE toggle).
@@ -957,7 +963,7 @@ export default function Page() {
             width: sessionPanelWidth(),
           }}
         >
-          <div class="flex-1 min-h-0 overflow-hidden">
+          <div class="relative flex-1 min-h-0 overflow-hidden">
             <Switch>
               <Match when={params.id}>
                 <Show when={messagesReady()}>
@@ -976,7 +982,10 @@ export default function Page() {
                     actions={actions}
                     scroll={ui.scroll}
                     onResumeScroll={resumeScroll}
-                    setScrollRef={setScrollRef}
+                    setScrollRef={(el) => {
+                      setScrollRef(el)
+                      setScrollEl(el)
+                    }}
                     onScheduleScrollState={scheduleScrollState}
                     onAutoScrollHandleScroll={autoScroll.handleScroll}
                     onMarkScrollGesture={markScrollGesture}
@@ -996,6 +1005,7 @@ export default function Page() {
                     renderedUserMessages={historyWindow.renderedUserMessages()}
                     anchor={anchor}
                   />
+                  <PromptIndex messages={visibleUserMessages} scrollEl={scrollEl} />
                 </Show>
               </Match>
               <Match when={true}>

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -25,7 +25,7 @@ import { Separator } from "@/primitives/separator"
 import { Tabs } from "@unifia/ui/tabs"
 import { createSessionScroll } from "@/pages/session/session-scroll"
 import { showToast } from "@unifia/ui/toast"
-import { useSearchParams } from "@solidjs/router"
+import { useNavigate, useSearchParams } from "@solidjs/router"
 import { NewSessionView, SessionHeader } from "@/components/session"
 import { useComments } from "@/context/comments"
 import { useGlobalSync } from "@/context/global-sync"
@@ -81,6 +81,7 @@ export default function Page() {
   const comments = useComments()
   const terminal = useTerminal()
   const [searchParams, setSearchParams] = useSearchParams<{ prompt?: string }>()
+  const navigate = useNavigate()
   const workbench = useWorkspaceWorkbench()
   const [artifactDocument, setArtifactDocument] = createSignal<{ filename: string; content: string }>()
   const [artifactError, setArtifactError] = createSignal<string>()
@@ -792,6 +793,7 @@ export default function Page() {
     userMessages,
     revertMessageID,
     language,
+    navigate,
   })
 
   const {

--- a/packages/app/src/pages/session/prompt-index.tsx
+++ b/packages/app/src/pages/session/prompt-index.tsx
@@ -1,0 +1,128 @@
+/* SPDX-License-Identifier: MIT */
+
+// A3-01 prompt index (v110 "prompt graduation ticks", INTERACTIONS.md
+// §Chat). Ported from the maquette's v45 iteration (the last of four:
+// v39/v43/v44/v45) behind Unifia-v110-module-043 -- same contract (one
+// tick per visible user prompt, hover/focus reveal, click scrolls the
+// target to ~28% of the viewport, active tick tracks the last prompt
+// whose top has crossed the vertical center), reimplemented on Solid
+// reactivity instead of a MutationObserver rebuilding DOM nodes by
+// hand: `props.messages` is already the reactive, already-filtered
+// (revert-aware) source the demo's observer existed only to fake.
+//
+// Simplification versus the maquette, noted rather than silently
+// dropped: reveal triggers on hovering/focusing the index itself and
+// on scrolling the thread, not on cursor proximity to the scrollbar
+// edge specifically. The behavioral contract (hidden by default,
+// appears during interaction, click still navigates) is preserved.
+
+import { For, Show, createMemo, createSignal, onCleanup, onMount } from "solid-js"
+import { Tooltip } from "@unifia/ui/tooltip"
+import type { UserMessage, TextPart } from "@/types/sdk-shim"
+import { useSync } from "@/context/sync"
+import { useLanguage } from "@/context/language"
+
+function firstPhrase(text: string): string {
+  const clean = text.replace(/\s+/g, " ").trim()
+  const match = clean.match(/^(.{1,140}?[.!?](?:\s|$)|.{1,100})/)
+  return (match?.[1] ?? clean).trim()
+}
+
+export function PromptIndex(props: { messages: () => UserMessage[]; scrollEl: () => HTMLElement | undefined }) {
+  const sync = useSync()
+  const language = useLanguage()
+  const [active, setActive] = createSignal(-1)
+  const [visible, setVisible] = createSignal(false)
+  let hideTimer: ReturnType<typeof setTimeout> | undefined
+
+  const ticks = createMemo(() =>
+    props.messages().map((message) => {
+      const parts = sync.data.part[message.id] ?? []
+      const textPart = parts.find((p): p is TextPart => p.type === "text" && !p.synthetic)
+      return { id: message.id, preview: firstPhrase(textPart?.text ?? "") }
+    }),
+  )
+
+  const targetEl = (id: string) => props.scrollEl()?.querySelector<HTMLElement>(`[data-message-id="${id}"]`)
+
+  const updateActive = () => {
+    const root = props.scrollEl()
+    if (!root) return
+    const center = root.getBoundingClientRect().top + root.clientHeight / 2
+    let best = 0
+    ticks().forEach((tick, i) => {
+      const el = targetEl(tick.id)
+      if (el && el.getBoundingClientRect().top <= center) best = i
+    })
+    setActive(best)
+  }
+
+  const show = () => {
+    clearTimeout(hideTimer)
+    setVisible(true)
+  }
+  const hideLater = (ms = 300) => {
+    clearTimeout(hideTimer)
+    hideTimer = setTimeout(() => setVisible(false), ms)
+  }
+
+  onMount(() => {
+    const root = props.scrollEl()
+    if (!root) return
+    const onScroll = () => {
+      updateActive()
+      show()
+      hideLater(420)
+    }
+    root.addEventListener("scroll", onScroll, { passive: true })
+    updateActive()
+    onCleanup(() => root.removeEventListener("scroll", onScroll))
+  })
+
+  const goTo = (index: number) => {
+    const root = props.scrollEl()
+    const tick = ticks()[index]
+    if (!root || !tick) return
+    const el = targetEl(tick.id)
+    if (!el) return
+    const rootTop = root.getBoundingClientRect().top
+    const elTop = el.getBoundingClientRect().top
+    const target = Math.max(
+      0,
+      Math.min(root.scrollHeight - root.clientHeight, root.scrollTop + (elTop - rootTop) - root.clientHeight * 0.28),
+    )
+    setActive(index)
+    root.scrollTo({ top: target, behavior: "smooth" })
+  }
+
+  return (
+    <Show when={ticks().length > 1}>
+      <nav
+        data-v110="prompt-index"
+        data-component="prompt-index"
+        aria-label={language.t("session.promptIndex.label")}
+        classList={{ "prompt-index": true, visible: visible() }}
+        onPointerEnter={show}
+        onPointerLeave={() => hideLater(300)}
+        onFocusIn={show}
+        onFocusOut={() => hideLater(300)}
+      >
+        <For each={ticks()}>
+          {(tick, i) => (
+            <Tooltip value={tick.preview} placement="left" gutter={8}>
+              <button
+                type="button"
+                class="prompt-index-tick"
+                classList={{ active: i() === active() }}
+                aria-label={tick.preview}
+                onClick={() => goTo(i())}
+              >
+                <span class="prompt-index-tick-line" />
+              </button>
+            </Tooltip>
+          )}
+        </For>
+      </nav>
+    </Show>
+  )
+}

--- a/packages/app/src/pages/session/session-mutations.ts
+++ b/packages/app/src/pages/session/session-mutations.ts
@@ -7,6 +7,7 @@
  */
 import { batch, createMemo } from "solid-js"
 import { useMutation } from "@tanstack/solid-query"
+import type { useNavigate } from "@solidjs/router"
 import { showToast } from "@unifia/ui/toast"
 import type { UserMessage } from "../../types/sdk-shim"
 import type { useSDK } from "@/context/sdk"
@@ -32,10 +33,11 @@ export interface SessionMutationsDeps {
   userMessages: () => UserMessage[]
   revertMessageID: () => string | undefined
   language: ReturnType<typeof useLanguage>
+  navigate: ReturnType<typeof useNavigate>
 }
 
 export function createSessionMutations(deps: SessionMutationsDeps) {
-  const { sdk, sync, params, info, prompt, userMessages, revertMessageID, language } = deps
+  const { sdk, sync, params, info, prompt, userMessages, revertMessageID, language, navigate } = deps
 
   // ── Draft / display helpers ──────────────────────────────────────────────
 
@@ -162,10 +164,32 @@ export function createSessionMutations(deps: SessionMutationsDeps) {
     },
   }))
 
+  // ── Fork mutation ───────────────────────────────────────────────────────────
+  // Branches a new session from a past user message (message-level entry
+  // point to the same sdk.client.session.fork() that dialog-fork.tsx's
+  // message picker already uses). No optimistic roll(): fork does not
+  // mutate the current session, it navigates away to a new one.
+
+  const forkMutation = useMutation(() => ({
+    mutationFn: async (input: { sessionID: string; messageID: string }) => {
+      const dir = params.dir
+      if (!dir) return
+      const restored = draft(input.messageID)
+      const result = await sdk.client.session.fork(input)
+      if (!result.data) {
+        fail(new Error(language.t("common.requestFailed")))
+        return
+      }
+      prompt.set(restored, undefined, { dir, id: result.data.id })
+      navigate(`/${dir}/session/${result.data.id}`)
+    },
+  }))
+
   // ── Derived state ─────────────────────────────────────────────────────────
 
   const reverting = createMemo(() => revertMutation.isPending || restoreMutation.isPending)
   const restoring = createMemo(() => (restoreMutation.isPending ? restoreMutation.variables : undefined))
+  const forking = createMemo(() => forkMutation.isPending)
 
   const revert = (input: { sessionID: string; messageID: string }) => {
     if (reverting()) return
@@ -177,6 +201,11 @@ export function createSessionMutations(deps: SessionMutationsDeps) {
     return restoreMutation.mutateAsync(id)
   }
 
+  const fork = (input: { sessionID: string; messageID: string }) => {
+    if (forking()) return
+    return forkMutation.mutateAsync(input)
+  }
+
   const rolled = createMemo(() => {
     const id = revertMessageID()
     if (!id) return []
@@ -185,7 +214,7 @@ export function createSessionMutations(deps: SessionMutationsDeps) {
       .map((item) => ({ id: item.id, text: line(item.id) }))
   })
 
-  const actions = { revert }
+  const actions = { revert, fork }
 
-  return { fail, busy, reverting, restoring, revert, restore, rolled, actions }
+  return { fail, busy, reverting, restoring, forking, revert, restore, fork, rolled, actions }
 }

--- a/packages/app/src/pages/session/v110-chat.css
+++ b/packages/app/src/pages/session/v110-chat.css
@@ -1,0 +1,67 @@
+/* SPDX-License-Identifier: MIT */
+
+/* A3-01 prompt index (v110 "prompt graduation ticks"). Desktop/tablet
+ * only: hover/proximity reveal has no touch equivalent, and the ticks
+ * would just crowd a phone-width thread. Breakpoint authority is the
+ * `shell:` variant A2 introduced (tokens/viewport.ts COMPACT, 900px),
+ * not a second responsive taxonomy.
+ */
+.prompt-index {
+  display: none;
+}
+
+@media (min-width: 56.25rem) {
+  .prompt-index {
+    position: absolute;
+    top: 50%;
+    right: 8px;
+    transform: translateY(-50%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 4px;
+    z-index: 5;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 160ms ease-out;
+  }
+
+  .prompt-index.visible {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
+.prompt-index-tick {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 14px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.prompt-index-tick-line {
+  width: 10px;
+  height: 2px;
+  border-radius: 1px;
+  background: var(--border-weaker-base);
+  transition:
+    width 140ms ease-out,
+    background 140ms ease-out;
+}
+
+.prompt-index-tick:hover .prompt-index-tick-line,
+.prompt-index-tick:focus-visible .prompt-index-tick-line {
+  width: 16px;
+  background: var(--text-weak);
+}
+
+.prompt-index-tick.active .prompt-index-tick-line {
+  width: 16px;
+  background: var(--icon-interactive-base);
+}

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -935,9 +935,11 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
   const [state, setState] = createStore({
     copied: false,
     busy: false,
+    forking: false,
   })
   const copied = () => state.copied
   const busy = () => state.busy
+  const forking = () => state.forking
 
   const textPart = createMemo(
     () => props.parts?.find((p) => p.type === "text" && !(p as TextPart).synthetic) as TextPart | undefined,
@@ -1000,6 +1002,20 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
         }),
       )
       .finally(() => setState("busy", false))
+  }
+
+  const fork = () => {
+    const act = props.actions?.fork
+    if (!act || forking()) return
+    setState("forking", true)
+    void Promise.resolve()
+      .then(() =>
+        act({
+          sessionID: props.message.sessionID,
+          messageID: props.message.id,
+        }),
+      )
+      .finally(() => setState("forking", false))
   }
 
   return (
@@ -1078,6 +1094,22 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
                     revert()
                   }}
                   aria-label={i18n.t("ui.message.revertMessage")}
+                />
+              </Tooltip>
+            </Show>
+            <Show when={props.actions?.fork}>
+              <Tooltip value={i18n.t("command.session.fork")} placement="top" gutter={4}>
+                <IconButton
+                  icon="fork"
+                  size="normal"
+                  variant="ghost"
+                  disabled={!!forking()}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    fork()
+                  }}
+                  aria-label={i18n.t("command.session.fork")}
                 />
               </Tooltip>
             </Show>


### PR DESCRIPTION
First A3 PR (Jalon 1, Chat/Session). Wave 0.5 (Shell) is closed — WAVE05_CANDIDATE_SHA 2fd03d0d04e2935e0e1a80cfabe89708197024ca.

Two commits, both additive, ~290 LOC combined:

**fork/branch as an inline message hover action** — copy and revert (rewind) were already wired on messages; fork was defined in `UserActions` since introduced but never actually consumed (verified: zero call sites before this PR). The operation already ships via `dialog-fork.tsx`'s picker dialog; this wires the same `sdk.client.session.fork()` call directly onto the message you're already looking at.

**Prompt graduation ticks** — INTERACTIONS.md's Chat contract specifies a per-prompt navigation rail (hover-reveal, tooltip preview, click-to-scroll, active-tick tracking). Ported the behavioral contract from the maquette's last iteration (v45, module 043) onto Solid reactivity instead of its DOM-mutation-observer approach — `visibleUserMessages()` is already reactive and already revert-aware, no observer needed. One noted simplification: reveal triggers on hover/focus of the index and thread scroll, not on cursor proximity to the scrollbar edge specifically.

Both verified: `bun typecheck` 47/47, i18n parity test 7/7, biome clean.