### PR TITLE
feat(a4-01): data-v110 markers on the real Code chrome

### DIFF
--- a/packages/app/e2e/v110/a4-code-chrome.spec.ts
+++ b/packages/app/e2e/v110/a4-code-chrome.spec.ts
@@ -1,0 +1,51 @@
+/* SPDX-License-Identifier: MIT */
+
+// A4-01: data-v110 markers on the real Code chrome (file tab bar, editor
+// content, terminal panel) so future A4/A8 checks can target them without
+// re-deriving selectors. No behavior change — same components file-tree.spec.ts
+// already exercises, just anchored with stable markers.
+//
+// Deliberately does not open the terminal: ghostty-web PTY startup is a known
+// CI-latency source (tracked via PLAYWRIGHT_SKIP_TERMINAL, see #71's
+// diagnosis) — checking the panel is attached (it always mounts, just
+// aria-hidden when closed) proves the marker exists without paying that cost.
+
+import { test, expect } from "../fixtures"
+
+test("code chrome markers: file tab bar, editor content, terminal panel", async ({ page, gotoSession }) => {
+  await gotoSession()
+
+  const toggle = page.getByRole("button", { name: "Toggle file tree" })
+  if ((await toggle.getAttribute("aria-expanded")) !== "true") await toggle.click()
+  await expect(toggle).toHaveAttribute("aria-expanded", "true")
+
+  const panel = page.locator('[data-v110="inspector-content"]')
+  const treeTabs = panel.locator('[data-component="tabs"][data-variant="pill"][data-scope="filetree"]')
+  const allTab = treeTabs.getByRole("tab", { name: /^all files$/i })
+  await allTab.click()
+
+  const tree = treeTabs.locator('[data-slot="tabs-content"]:not([hidden])')
+  const expand = async (name: string) => {
+    const folder = tree.getByRole("button", { name, exact: true }).first()
+    await expect(folder).toBeVisible()
+    if ((await folder.getAttribute("aria-expanded")) === "false") await folder.click()
+    await expect(folder).toHaveAttribute("aria-expanded", "true")
+  }
+  await expand("packages")
+  await expand("app")
+  await expand("src")
+  await expand("components")
+
+  const file = tree.getByRole("button", { name: "file-tree.tsx", exact: true }).first()
+  await expect(file).toBeVisible()
+  await file.click()
+
+  await page.getByRole("tab", { name: "Inspector", exact: true }).click()
+
+  await expect(page.locator('[data-v110="code-tabs"]')).toBeVisible()
+  await expect(page.locator('[data-v110="code-editor"]')).toBeVisible()
+
+  // Always mounted (height:0 + aria-hidden when closed), not conditionally
+  // rendered — attached is the correct assertion, not visible.
+  await expect(page.locator('[data-v110="code-terminal"]')).toBeAttached()
+})

--- a/packages/app/src/pages/session/file-tabs.tsx
+++ b/packages/app/src/pages/session/file-tabs.tsx
@@ -194,8 +194,13 @@ export function FileTabContent(props: { tab: string; override?: boolean }) {
   // avoid defining a component inside the function body (causes remounts).
   const tabsContentProps = () =>
     props.override
-      ? { component: "div" as const, class: "mt-3 relative h-full overflow-auto" }
-      : { component: Tabs.Content as any, value: props.tab, class: "mt-3 relative h-full" }
+      ? { component: "div" as const, class: "mt-3 relative h-full overflow-auto", "data-v110": "code-editor" }
+      : {
+          component: Tabs.Content as any,
+          value: props.tab,
+          class: "mt-3 relative h-full",
+          "data-v110": "code-editor",
+        }
 
   return (
     <Dynamic {...tabsContentProps()}>

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -523,6 +523,7 @@ export function SessionSidePanel(props: {
                       <Tabs value={activeTab()} onChange={openTab} class="flex-1 min-h-0">
                         <div class="sticky top-0 shrink-0 flex">
                           <Tabs.List
+                            data-v110="code-tabs"
                             ref={(el: HTMLDivElement) => {
                               const stop = createFileTabListSync({ el, contextOpen })
                               onCleanup(stop)

--- a/packages/app/src/pages/session/terminal-panel.tsx
+++ b/packages/app/src/pages/session/terminal-panel.tsx
@@ -424,6 +424,7 @@ export function TerminalPanel() {
     <div
       ref={root}
       id="terminal-panel"
+      data-v110="code-terminal"
       role="region"
       aria-label={language.t("terminal.title")}
       aria-hidden={!opened()}


### PR DESCRIPTION
## Summary

Jalon 2 (A4 — Code + Browser) recon found the Code surface's real functionality already far more complete than the mockup: `code-mirror-lsp.ts` already wires real diagnostics gutter, hover, F12 go-to-definition, F2 rename, Ctrl+. code actions, Shift+F12 references and LSP autocomplete; `file-tabs.tsx` already has rename/code-action/references panels, scroll sync, comment overlays and split-editor (Ctrl+\). Per COMPONENT-MAP.md's own verdict this is "KEEP contrat + REFACTOR representation" — no missing capability to build.

Browser needs zero work: `v110-store.ts` already documents GAP-01/GAP-02 (SHELL_MODES is `code/work/design/automate` only — Browser is a destination, not a mode; no fake browser navigation), confirmed by `mode.test.ts`/`v110-store.test.ts`.

This PR is the resulting first slice: `data-v110` markers on the three real Code chrome anchors — file tab bar (`code-tabs`), editor content (`code-editor`), terminal panel (`code-terminal`) — mirroring the pattern A2/A3 used for the shell frame and Inspector content, so future A4/A8 checks can target the real surface. No behavior change.

## Why this needed a rebase first

`session-side-panel.tsx` (where two of these markers land) was being actively restructured by A3's Jalon-1 PRs (#72/#73/#76/#78) when this branch started. Merged all four into `feat/ui-v110-port` first (filing #79 for an unrelated pre-existing Windows CI finding surfaced along the way — 68 memory/vault unit tests failing identically across all 4 PRs, confirmed via diff inspection to be untouched by any of them), then rebased this branch onto the merged result before making these edits.

## Test plan

- [x] `bun run typecheck` — 47/47 packages green
- [x] `bun test --preload ./happydom.ts ./src` (packages/app) — 1233/1233 green
- [x] New e2e `e2e/v110/a4-code-chrome.spec.ts` run against a live local backend — passes, verifies all three markers render for a real opened file
- [x] `bunx biome check` on touched files — clean